### PR TITLE
Download centroids.pickle before using it

### DIFF
--- a/pywren-annotation-example-pipeline.ipynb
+++ b/pywren-annotation-example-pipeline.ipynb
@@ -785,9 +785,15 @@
    "outputs": [],
    "source": [
     "def annotate_segm_spectra(key, data_stream, ibm_cos):\n",
-    "    centroids_stream = ibm_cos.get_object(Bucket=bucket_name, Key=input_db['centroids_pandas'])['Body']\n",
-    "    centroids_df = pickle.loads(centroids_stream.read())\n",
     "    spectra = pickle.loads(data_stream.read())\n",
+    "    \n",
+    "    if not os.path.isfile('/tmp/centroids.pickle'):\n",
+    "        print(\"Read centroids DB from IBM COS\")\n",
+    "        ibm_cos.download_file(bucket_name, input_db['centroids_pandas'], '/tmp/centroids.pickle')\n",
+    "    \n",
+    "    with open('/tmp/centroids.pickle', 'rb') as centroids:\n",
+    "        centroids_df = pickle.load(centroids)\n",
+    "    \n",
     "    iso_images = gen_iso_images(spectra, pixel_indices, centroids_df, nrows, ncols, ppm=3)\n",
     "    formula_images = merge_formula_images(list(iso_images))\n",
     "    formula_scores_df = score_formula_images(formula_images, centroids_df, empty_image)\n",
@@ -896,7 +902,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.7"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
Changed the way to use centroids.pickle from a function.
Previous approach takes between 4.2 and 5.9 seconds to run these two lines:
```
centroids_stream = ibm_cos.get_object(Bucket=bucket_name, Key=input_db['centroids_pandas'])['Body']
centroids_df = pickle.loads(centroids_stream.read())
```

Current approach takes between 1.7 and 3.5 seconds to run these lines:
```
if not os.path.isfile('/tmp/centroids.pickle'):
    print("Read centroids DB from IBM COS")
    ibm_cos.download_file(bucket_name, input_db['centroids_pandas'], '/tmp/centroids.pickle')
    
with open('/tmp/centroids.pickle', 'rb') as centroids:
    centroids_df = pickle.load(centroids)
```
When the file is already downloaded in the runtime (consecutive executions),  load the pickle takes 0.2 seconds.