### PR TITLE
Add additional molecular databases

### DIFF
--- a/annotation_pipeline/annotation.py
+++ b/annotation_pipeline/annotation.py
@@ -92,7 +92,7 @@ def annotate_spectra(config, input_data, input_db, segm_n, pixel_indices, nrows,
 
         if not os.path.isfile('/tmp/centroids.pickle'):
             print("Read centroids DB from IBM COS")
-            ibm_cos.download_file(input_db["bucket"], input_db['centroids_pandas'], '/tmp/centroids.pickle')
+        ibm_cos.download_file(input_db["bucket"], input_db['centroids_pandas'], '/tmp/centroids.pickle')
 
         with open('/tmp/centroids.pickle', 'rb') as centroids:
             centroids_df = pickle.load(centroids)

--- a/annotation_pipeline/annotation.py
+++ b/annotation_pipeline/annotation.py
@@ -92,7 +92,7 @@ def annotate_spectra(config, input_data, input_db, segm_n, pixel_indices, nrows,
 
         if not os.path.isfile('/tmp/centroids.pickle'):
             print("Read centroids DB from IBM COS")
-        ibm_cos.download_file(input_db["bucket"], input_db['centroids_pandas'], '/tmp/centroids.pickle')
+            ibm_cos.download_file(input_db["bucket"], input_db['centroids_pandas'], '/tmp/centroids.pickle')
 
         with open('/tmp/centroids.pickle', 'rb') as centroids:
             centroids_df = pickle.load(centroids)

--- a/annotation_pipeline/formula_parser.py
+++ b/annotation_pipeline/formula_parser.py
@@ -1,0 +1,60 @@
+import re
+from collections import Counter
+
+clean_regexp = re.compile(r'[.=]')
+formula_regexp = re.compile(r'([A-Z][a-z]*)([0-9]*)')
+adduct_split_regexp = re.compile(r'([+-]*)([A-Za-z0-9]+)')
+
+
+class ParseFormulaError(Exception):
+    def __init__(self, message):
+        self.message = message
+
+
+def parse_formula(f):
+    return [(elem, int(n or '1'))
+            for (elem, n) in formula_regexp.findall(f)]
+
+
+def generate_ion_formula(formula, *adducts):
+    formula = clean_regexp.sub('', formula)
+    adducts = [clean_regexp.sub('', adduct) for adduct in adducts]
+
+    ion_elements = Counter(dict(parse_formula(formula)))
+
+    for adduct in adducts:
+        op, a_formula = adduct_split_regexp.findall(adduct)[0]
+        assert op in ('+','-'), 'Adduct should be prefixed with + or -'
+        if op == '+':
+            for elem, n in parse_formula(a_formula):
+                ion_elements[elem] += n
+        else:
+            for elem, n in parse_formula(a_formula):
+                ion_elements[elem] -= n
+                if ion_elements[elem] < 0:
+                    raise ParseFormulaError(f'Negative total element count for {elem}')
+
+    # Ordered per https://en.wikipedia.org/wiki/Chemical_formula#Hill_system
+    if ion_elements['C'] != 0:
+        element_order = ['C', 'H', *sorted(key for key in ion_elements.keys() if key not in ('C', 'H'))]
+    elif any(count > 0 for count in ion_elements.values()):
+        element_order = sorted(key for key in ion_elements.keys())
+    else:
+        raise ParseFormulaError('No remaining elements')
+
+    ion_formula_parts = []
+    for elem in element_order:
+        count = ion_elements[elem]
+        if count != 0:
+            ion_formula_parts.append(elem)
+            if count > 1:
+                ion_formula_parts.append(str(count))
+
+    return ''.join(ion_formula_parts)
+
+
+def safe_generate_ion_formula(*parts):
+    try:
+        return generate_ion_formula(*(part for part in parts if part))
+    except ParseFormulaError:
+        return None

--- a/annotation_pipeline/isocalc_wrapper.py
+++ b/annotation_pipeline/isocalc_wrapper.py
@@ -1,0 +1,76 @@
+from cpyMSpec import isotopePattern, InstrumentModel
+from pyMSpec.pyisocalc import pyisocalc
+import numpy as np
+import logging
+
+
+logger = logging.getLogger('engine')
+
+ISOTOPIC_PEAK_N = 4
+SIGMA_TO_FWHM = 2.3548200450309493  # 2 \sqrt{2 \log 2}
+
+
+class IsocalcWrapper(object):
+    """ Wrapper around pyMSpec.pyisocalc.pyisocalc used for getting theoretical isotope peaks'
+    centroids and profiles for a sum formula.
+
+    Args
+    ----------
+    isocalc_config : dict
+        Dictionary representing isotope_generation section of a dataset config file
+    """
+
+    def __init__(self, isocalc_config):
+        self.charge = 0
+        if 'polarity' in isocalc_config['charge']:
+            polarity = isocalc_config['charge']['polarity']
+            self.charge = (-1 if polarity == '-' else 1) * isocalc_config['charge']['n_charges']
+        self.sigma = float(isocalc_config['isocalc_sigma'])
+        self.n_peaks = isocalc_config.get('n_peaks', ISOTOPIC_PEAK_N)
+        # self.pts_per_mz = int(isocalc_config['isocalc_pts_per_mz'])
+
+    @staticmethod
+    def _trim(mzs, ints, k):
+        """ Only keep top k peaks
+        """
+        int_order = np.argsort(ints)[::-1]
+        mzs = mzs[int_order][:k]
+        ints = ints[int_order][:k]
+        mz_order = np.argsort(mzs)
+        mzs = mzs[mz_order]
+        ints = ints[mz_order]
+        return mzs, ints
+
+    def centroids(self, formula):
+        """
+        Args
+        -----
+        formula : str
+
+        Returns
+        -----
+            list[tuple]
+        """
+        try:
+            pyisocalc.parseSumFormula(formula)  # tests that formula is parsable
+            iso_pattern = isotopePattern(str(formula))
+            iso_pattern.addCharge(int(self.charge))
+            fwhm = self.sigma * SIGMA_TO_FWHM
+            resolving_power = iso_pattern.masses[0] / fwhm
+            instrument_model = InstrumentModel('tof', resolving_power)
+            centr = iso_pattern.centroids(instrument_model)
+            mzs_ = np.array(centr.masses)
+            ints_ = 100. * np.array(centr.intensities)
+            mzs_, ints_ = self._trim(mzs_, ints_, self.n_peaks)
+
+            n = len(mzs_)
+            mzs = np.zeros(self.n_peaks)
+            mzs[:n] = np.array(mzs_)
+            ints = np.zeros(self.n_peaks)
+            ints[:n] = ints_
+
+            return mzs, ints
+
+        except Exception as e:
+            logger.warning('%s - %s', formula, e)
+            return None, None

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -1,6 +1,22 @@
+import os
+from itertools import repeat
+
+import ibm_boto3
+from ibm_botocore.client import Config
 import pywren_ibm_cloud as pywren
 import pandas as pd
 import pickle
+
+from .formula_parser import safe_generate_ion_formula
+
+
+DECOY_ADDUCTS = ['+He', '+Li', '+Be', '+B', '+C', '+N', '+O', '+F', '+Ne', '+Mg', '+Al', '+Si', '+P', '+S', '+Cl', '+Ar', '+Ca', '+Sc', '+Ti', '+V', '+Cr', '+Mn', '+Fe', '+Co', '+Ni', '+Cu', '+Zn', '+Ga', '+Ge', '+As', '+Se', '+Br', '+Kr', '+Rb', '+Sr', '+Y', '+Zr', '+Nb', '+Mo', '+Ru', '+Rh', '+Pd', '+Ag', '+Cd', '+In', '+Sn', '+Sb', '+Te', '+I', '+Xe', '+Cs', '+Ba', '+La', '+Ce', '+Pr', '+Nd', '+Sm', '+Eu', '+Gd', '+Tb', '+Dy', '+Ho', '+Ir', '+Th', '+Pt', '+Os', '+Yb', '+Lu', '+Bi', '+Pb', '+Re', '+Tl', '+Tm', '+U', '+W', '+Au', '+Er', '+Hf', '+Hg', '+Ta']
+
+def get_cos_client(config):
+    return ibm_boto3.client(service_name='s3',
+                            ibm_api_key_id=config['ibm_cos']['api_key'],
+                            config=Config(signature_version='oauth'),
+                            endpoint_url=config['ibm_cos']['endpoint'])
 
 
 def process_formulas_database(config, input_db):
@@ -22,11 +38,148 @@ def store_centroids_database(config, input_db):
         centroids_df = pd.read_csv(data_stream._raw_stream).set_index('formula_i')
         ibm_cos.put_object(Bucket=input_db['bucket'], Key=input_db['centroids_pandas'], Body=pickle.dumps(centroids_df))
         return centroids_df.shape, centroids_df.head(8)
-    
+
     pw = pywren.ibm_cf_executor(config=config, runtime_memory=1024)
     iterdata = [f'{input_db["bucket"]}/{input_db["centroids"]}']
     pw.map(store_centroids, iterdata)
     centroids_shape, centroids_head = pw.get_result()
     pw.clean()
-    
+
     return centroids_shape, centroids_head
+
+
+def calculate_centroids(config, input_db, formula_chunk_keys):
+    def calculate_peaks_for_formula(formula_i, formula):
+        mzs, ints = isocalc_wrapper.centroids(formula)
+        if mzs is not None:
+            return list(zip(repeat(formula_i), range(len(mzs)), mzs, ints))
+        else:
+            return []
+
+    def calculate_peaks_for_chunk(key, data_stream):
+        chunk_df = pd.read_pickle(data_stream._raw_stream)
+        peaks = [peak for formula_i, formula in chunk_df.formula.items()
+                 for peak in calculate_peaks_for_formula(formula_i, formula)]
+        peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
+        return peaks_df
+
+    def calculate_peaks_for_chunk_local(chunk_key, i):
+        print(i, 'out of', len(formula_chunk_keys))
+        chunk_df = pickle.loads(ibm_cos.get_object(Bucket=input_db["bucket"], Key=chunk_key)['Body'].read())
+        peaks = [peak for formula_i, formula in chunk_df.formula.items()
+                      for peak in calculate_peaks_for_formula(formula_i, formula)]
+        peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
+        return peaks_df
+
+    def merge_chunks_and_store(chunks, ibm_cos):
+        centroids_df = pd.concat(chunks).set_index('formula_i')
+        ibm_cos.put_object(Bucket=input_db['bucket'], Key=input_db['centroids_pandas'], Body=pickle.dumps(centroids_df))
+        return centroids_df.shape, centroids_df.head(8)
+
+    from .isocalc_wrapper import IsocalcWrapper # Import lazily so that the rest of the pipeline still works if the dependency is missing
+    isocalc_wrapper = IsocalcWrapper({
+        # These instrument settings are usually customized on a per-dataset basis,
+        # but most of EMBL's datasets use these settings:
+        'charge': {
+            'polarity': '+',
+            'n_charges': 1,
+        },
+        'isocalc_sigma': 0.001238
+    })
+
+    # TODO: Switch to pywren codepath when cpyMSpec is in the runtime
+    # pw = pywren.ibm_cf_executor(config=config, runtime_memory=1024)
+    # iterdata = [f'{input_db["bucket"]}/{chunk_key}' for chunk_key in formula_chunk_keys]
+    # futures = pw.map_reduce(calculate_peaks_for_chunk, iterdata, merge_chunks_and_store)
+    # centroids_shape, centroids_head = pw.get_result(futures)
+    # pw.clean()
+
+    ibm_cos = get_cos_client(config)
+
+    from concurrent.futures import ThreadPoolExecutor
+    with ThreadPoolExecutor(max_workers=(os.cpu_count() or 1)) as ex:
+        all_chunks = list(ex.map(calculate_peaks_for_chunk_local, formula_chunk_keys, range(len(formula_chunk_keys))))
+    centroids_shape, centroids_head = merge_chunks_and_store(all_chunks, ibm_cos)
+
+    return centroids_shape, centroids_head
+
+
+def build_database(config, input_db, n_formula_chunks=256):
+    def generate_formulas(key, data_stream, adducts, modifiers):
+        db = pd.read_csv(data_stream._raw_stream)
+        dfs = []
+
+        for adduct in adducts:
+            for modifier in modifiers:
+                formulas = db.apply(lambda row: safe_generate_ion_formula(row.sf, adduct, modifier), axis=1)
+                df = db.assign(formula=formulas, adduct=adduct, modifier=modifier)
+                df = df[formulas != None]
+                dfs.append(df)
+
+        result = pd.concat(dfs)
+
+        return result
+
+    def store_formulas(results, ibm_cos):
+        ions = pd.concat(results)
+        ions.sort_values(['sf','adduct','modifier'], inplace=True)
+        ions.reset_index(drop=True, inplace=True)
+        ions.index.name = 'ion_i'
+
+        # Reduce list of formulas for processing to include only unique formulas
+        formulas = ions[['formula']].drop_duplicates().sort_values(by='formula').reset_index(drop=True)
+        formulas.index.name = 'formula_i'
+
+        # Add formula IDs to ions so that ions can be mapped back to formulas
+        ions = ions.merge(formulas.reset_index(), on='formula', how='outer')
+
+        num_chunks = min(len(formulas), n_formula_chunks)
+        chunk_keys = []
+
+        # Write pickled chunks equivalent to formulas.csv with (formula_i, formula)
+        for i in range(num_chunks):
+            lo = len(formulas) * i // num_chunks
+            hi = len(formulas) * (i + 1) // num_chunks
+            chunk_key = f'{input_db["formulas_dir"]}/{i}.pickle'
+            chunk_keys.append(chunk_key)
+            chunk = pd.DataFrame(formulas.formula[lo:hi], copy=True)
+            chunk.index.name = 'formula_i'
+
+            ibm_cos.put_object(Bucket=input_db['bucket'], Key=chunk_key,
+                               Body=pickle.dumps(chunk))
+
+        # Write full dataframe to pickle so that molecules can be matched after annotation for further analysis
+        ibm_cos.put_object(Bucket=input_db['bucket'], Key=input_db['ions_full'],
+                           Body=pickle.dumps(ions))
+
+        return chunk_keys
+
+    adducts = [*input_db.get('adducts', ['+H', '+Na', '+K']), *DECOY_ADDUCTS]
+    modifiers = input_db.get('modifiers') or ['']
+    databases = input_db['databases']
+
+    ibm_cos = get_cos_client(config)
+    pw = pywren.ibm_cf_executor(config=config, runtime_memory=512)
+    iterdata = [(f'{input_db["bucket"]}/{database}', [adduct], modifiers) for database in databases for adduct in adducts]
+    # TODO: Fix OOM in reducer. Maybe by handling ions_full separately because it's much bigger and not needed until after FDR ranking
+    # futures = pw.map_reduce(generate_formulas, iterdata, store_formulas)
+    # formula_chunk_keys = pw.get_result(futures)
+    futures = pw.map(generate_formulas, iterdata)
+    results = pw.get_result(futures)
+    formula_chunk_keys = store_formulas(results, ibm_cos)
+    pw.clean()
+
+    return formula_chunk_keys
+
+
+def clean_formula_chunks(config, input_db, formula_chunk_keys):
+    ibm_cos = get_cos_client(config)
+    ibm_cos.delete_objects(Bucket=input_db['bucket'],
+                           Delete={'Objects': [{'Key': key} for key in formula_chunk_keys]})
+
+
+def dump_mol_db_to_file(db_id, file):
+    import requests
+    mols = requests.get(f'https://metaspace2020.eu/mol_db/v1/databases/{db_id}/molecules?limit=999999&fields=sf').json()['data']
+    mols_df = pd.DataFrame([mol['sf'] for mol in mols], columns=[['sf']]).drop_duplicates()
+    mols_df.to_csv(file)

--- a/input_config.json.template
+++ b/input_config.json.template
@@ -10,7 +10,17 @@
   "molecular_db": {
     "bucket": "****",
     "formulas": "metabolomics/db/formulas.csv",
+    "formulas_chunks": "metabolomics/db/formulas",
+    "ions_full": "metabolomics/db/ions_full.pickle",
     "centroids": "metabolomics/db/centroids.csv",
-    "centroids_pandas": "metabolomics/db/centroids.pickle"
+    "centroids_pandas": "metabolomics/db/centroids.pickle",
+    "databases": [
+      "metabolomics/db/mol_db1.csv",
+      "metabolomics/db/mol_db2.csv",
+      "metabolomics/db/mol_db3.csv",
+      "metabolomics/db/mol_db4.csv"
+    ],
+    "adducts": ["","+H","+Na","+K"],
+    "modifiers": ["", "-H2O", "-CO2", "-NH3"]
   }
 }

--- a/input_config.json.template
+++ b/input_config.json.template
@@ -11,14 +11,13 @@
     "bucket": "****",
     "formulas": "metabolomics/db/formulas.csv",
     "formulas_chunks": "metabolomics/db/formulas",
-    "ions_full": "metabolomics/db/ions_full.pickle",
     "centroids": "metabolomics/db/centroids.csv",
     "centroids_pandas": "metabolomics/db/centroids.pickle",
     "databases": [
-      "metabolomics/db/mol_db1.csv",
-      "metabolomics/db/mol_db2.csv",
-      "metabolomics/db/mol_db3.csv",
-      "metabolomics/db/mol_db4.csv"
+      "metabolomics/db/mol_db1.pickle",
+      "metabolomics/db/mol_db2.pickle",
+      "metabolomics/db/mol_db3.pickle",
+      "metabolomics/db/mol_db4.pickle"
     ],
     "adducts": ["","+H","+Na","+K"],
     "modifiers": ["", "-H2O", "-CO2", "-NH3"]

--- a/pywren-annotation-example-pipeline.ipynb
+++ b/pywren-annotation-example-pipeline.ipynb
@@ -204,7 +204,7 @@
    "source": [
     "import os\n",
     "\n",
-    "for dirpath, dirnames, filenames in os.walk('./metabolomics'):\n",
+    "for dirpath, dirnames, filenames in os.walk('./metabolomics/db'):\n",
     "    for fn in filenames:\n",
     "        f_path = f'{dirpath}/{fn}'\n",
     "        copy(f_path, input_data['bucket'], f_path)"
@@ -392,6 +392,91 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
+    "# Generate Isotopic Peaks from Molecular Databases"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from annotation_pipeline.molecular_db import dump_mol_db, build_database, calculate_centroids, clean_formula_chunks"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Download commonly used mol DBs from METASPACE (add force=True to redownload if needed)\n",
+    "dump_mol_db(config, input_db['bucket'], 'metabolomics/db/mol_db1.pickle', 22) #HMDB-v4\n",
+    "dump_mol_db(config, input_db['bucket'], 'metabolomics/db/mol_db2.pickle', 19) #ChEBI-2018-01\n",
+    "dump_mol_db(config, input_db['bucket'], 'metabolomics/db/mol_db3.pickle', 24) #LipidMaps-2017-12-12\n",
+    "dump_mol_db(config, input_db['bucket'], 'metabolomics/db/mol_db4.pickle', 26) #SwissLipids-2018-02-02"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "num_formulas, formula_chunk_keys = build_database(config, input_db)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "num_formulas, len(formula_chunk_keys), formula_chunk_keys[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%%time\n",
+    "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "centroids_shape"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "centroids_head"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "clean_formula_chunks(config, input_db, formula_chunk_keys)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
     "# Split Dataset into Segments"
    ]
   },
@@ -507,6 +592,15 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "formula_scores_df.shape, len(formula_images)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
     "img = formula_images[896952][0][1]\n",
     "plt.imshow(img.toarray())"
    ]
@@ -558,5 +652,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 1
+ "nbformat_minor": 2
 }

--- a/pywren-annotation-example-pipeline.ipynb
+++ b/pywren-annotation-example-pipeline.ipynb
@@ -204,7 +204,7 @@
    "source": [
     "import os\n",
     "\n",
-    "for dirpath, dirnames, filenames in os.walk('./metabolomics/db'):\n",
+    "for dirpath, dirnames, filenames in os.walk('./metabolomics'):\n",
     "    for fn in filenames:\n",
     "        f_path = f'{dirpath}/{fn}'\n",
     "        copy(f_path, input_data['bucket'], f_path)"
@@ -652,5 +652,5 @@
   }
  },
  "nbformat": 4,
- "nbformat_minor": 2
+ "nbformat_minor": 1
 }

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,9 @@ setup(name='pywren-annotation-pipeline',
       packages=find_packages(),
       install_requires=[
           "pywren-ibm-cloud>=1.0.8",
-          "pandas>=0.19.2",
+          # pandas version should match the version in the runtime to ensure data generated locally can be unpickled
+          # in pywren actions
+          "pandas==0.23.3",
           "pyImagingMSpec==0.1.4",
           "cpyImagingMSpec==0.3.2",
           "pyMSpec==0.1.2",

--- a/setup.py
+++ b/setup.py
@@ -17,5 +17,6 @@ setup(name='pywren-annotation-pipeline',
           "cpyImagingMSpec==0.3.2",
           "pyMSpec==0.1.2",
           "cpyMSpec==0.4.2",
-          "pyimzML==1.2.5"
+          "pyimzML==1.2.5",
+          "requests"
       ])


### PR DESCRIPTION
This change adds the popular molecular databases from METASPACE and several molecule modifiers to the centroids file. It downloads the molecules from https://metaspace2020.eu, combines them with the adducts & modifiers to generate molecular formulas, then calculates the isotopic patterns for the annotation engine to use.

Note that the `calculate_centroids` function currently runs without PyWren, as it needs the cpyMSpec C library. It takes ~27 minutes to run on a 4-core PC. 

Please copy the changes from `input_config.json.template` into your `input_config.json` files. Note that the size of the `centroids.pickle` file, and the amount of time required to run `calculate_centroids` is very dependent on the `"modifiers"` config option:
* With `"modifiers": [""]` it matches the current deployed behavior of METASPACE and `calculate_centroids` takes ~10 minutes
* With `"modifiers": ["", "-H2O"]`, `centroids.pickle` is ~488MB and `calculate_centroids` takes 18 minutes
* With `"modifiers": ["", "-H2O", "-CO2", "-NH3"]` it matches the behavior of a feature I'm currently working on - taking molecule fragmentation into account. `centroids.pickle` is 746MB and `calculate_centroids` takes ~27 minutes

`centroids.pickle` can be segmented by `mz` value in the same way & same `segm_intervals` as the dataset data, however it's probably not necessary yet. 2048MB runtimes works with the largest `centroids.pickle`, and it has been necessary to increase runtime sizes to prevent timeouts. I haven't tested this on the bigger datasets yet though.

`formula_parser.py` and `isocalc_wrapper.py` are copied directly from METASPACE's codebase and don't need review.

I don't suggest trying to optimize `calculate_centroids` and `build_database` aside from adding cpyMSpec into the runtime so that `calculate_centroids` can run in PyWren. These parts of the pipeline can be precalculated and cached for most common configurations.