### PR TITLE
Restructure notebook and enhance functionality

### DIFF
--- a/annotation_pipeline/__main__.py
+++ b/annotation_pipeline/__main__.py
@@ -8,17 +8,9 @@ import matplotlib.pyplot as plt
 
 from annotation_pipeline.imzml import convert_imzml_to_txt
 from annotation_pipeline.pipeline import annotate_dataset
+from annotation_pipeline.utils import get_ibm_cos_client
 
 logger = logging.getLogger(name='annotation_pipeline')
-
-
-def get_ibm_cos_client(config):
-    import ibm_boto3
-    from ibm_botocore.client import Config
-    return ibm_boto3.client(service_name='s3',
-                            ibm_api_key_id=config['ibm_cos']['api_key'],
-                            config=Config(signature_version='oauth'),
-                            endpoint_url=config['ibm_cos']['endpoint'])
 
 
 def annotate(args, config):

--- a/annotation_pipeline/annotation.py
+++ b/annotation_pipeline/annotation.py
@@ -107,7 +107,9 @@ def annotate_spectra(config, input_data, input_db, segm_n):
         return formula_scores_df, formula_images
 
     cos_client = get_ibm_cos_client(config)
-    spectra_coords_stream = cos_client.get_object(Bucket=input_data['bucket'], Key=input_data['ds_coord'])['Body']
+    ds_id = input_data['ds_id']
+    spectra_coords_stream = cos_client.get_object(Bucket=input_data['bucket'],
+                                                  Key=input_data['datasets'][ds_id]['ds_coord'])['Body']
     spectra_coords = parse_txt(None, spectra_coords_stream, parse_spectrum_coord)
     pixel_indices, nrows, ncols = real_pixel_indices(spectra_coords)
     empty_image = np.zeros((nrows, ncols))

--- a/annotation_pipeline/dataset.py
+++ b/annotation_pipeline/dataset.py
@@ -1,4 +1,3 @@
-import pywren_ibm_cloud as pywren
 import numpy as np
 import io
 
@@ -14,13 +13,6 @@ def parse_txt(key, data_stream, func):
     return rows
 
 
-def reduce_chunks(results):
-    final_result = []
-    for res_list in results:
-        final_result.extend(res_list)
-    return final_result
-
-
 def parse_spectrum_line(s):
     ind_s, mzs_s, int_s = s.split('|')
     return (int(ind_s),
@@ -28,29 +20,9 @@ def parse_spectrum_line(s):
             np.fromstring(int_s, sep=' '))
 
 
-def read_dataset_spectra(config, input_data):
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=512)
-    iterdata = [[f'{input_data["bucket"]}/{input_data["ds"]}', parse_spectrum_line]]
-    # NOTE: we need to be absolutely sure that using chunk_size doesn't split a line into separate chunks
-    pw.map_reduce(parse_txt, iterdata, reduce_chunks, chunk_size=64*1024**2)
-    spectra = pw.get_result()
-    pw.clean()
-
-    return spectra
-
-
-def read_dataset_coords(config, input_data):
-    def parse_spectrum_coord(s):
-        sp_i, x, y = map(int, s.split(','))
-        return sp_i, x, y
-
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=128)
-    iterdata = [[f'{input_data["bucket"]}/{input_data["ds_coord"]}', parse_spectrum_coord]]
-    pw.map(parse_txt, iterdata)
-    spectra_coords = pw.get_result()
-    pw.clean()
-
-    return spectra_coords
+def parse_spectrum_coord(s):
+    sp_i, x, y = map(int, s.split(','))
+    return sp_i, x, y
 
 
 def real_pixel_indices(spectra_coords):

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -2,51 +2,16 @@ import os
 from io import BytesIO
 from itertools import repeat
 
-import ibm_boto3
-from ibm_botocore.client import Config, ClientError
+from ibm_botocore.client import ClientError
 import pywren_ibm_cloud as pywren
 import pandas as pd
 import pickle
 
 from .formula_parser import safe_generate_ion_formula
+from .utils import get_ibm_cos_client
 
 
 DECOY_ADDUCTS = ['+He', '+Li', '+Be', '+B', '+C', '+N', '+O', '+F', '+Ne', '+Mg', '+Al', '+Si', '+P', '+S', '+Cl', '+Ar', '+Ca', '+Sc', '+Ti', '+V', '+Cr', '+Mn', '+Fe', '+Co', '+Ni', '+Cu', '+Zn', '+Ga', '+Ge', '+As', '+Se', '+Br', '+Kr', '+Rb', '+Sr', '+Y', '+Zr', '+Nb', '+Mo', '+Ru', '+Rh', '+Pd', '+Ag', '+Cd', '+In', '+Sn', '+Sb', '+Te', '+I', '+Xe', '+Cs', '+Ba', '+La', '+Ce', '+Pr', '+Nd', '+Sm', '+Eu', '+Gd', '+Tb', '+Dy', '+Ho', '+Ir', '+Th', '+Pt', '+Os', '+Yb', '+Lu', '+Bi', '+Pb', '+Re', '+Tl', '+Tm', '+U', '+W', '+Au', '+Er', '+Hf', '+Hg', '+Ta']
-
-def get_cos_client(config):
-    return ibm_boto3.client(service_name='s3',
-                            ibm_api_key_id=config['ibm_cos']['api_key'],
-                            config=Config(signature_version='oauth'),
-                            endpoint_url=config['ibm_cos']['endpoint'])
-
-
-def process_formulas_database(config, input_db):
-    def process_formulas(key, data_stream):
-        formulas_df = pd.read_csv(data_stream._raw_stream).set_index('formula_i')
-        return formulas_df.shape, formulas_df.head()
-
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=256)
-    iterdata = [f'{input_db["bucket"]}/{input_db["formulas"]}']
-    pw.map(process_formulas, iterdata)
-    formulas_shape, formulas_head = pw.get_result()
-    pw.clean()
-
-    return formulas_shape, formulas_head
-
-
-def store_centroids_database(config, input_db):
-    def store_centroids(key, data_stream, ibm_cos):
-        centroids_df = pd.read_csv(data_stream._raw_stream).set_index('formula_i')
-        ibm_cos.put_object(Bucket=input_db['bucket'], Key=input_db['centroids_pandas'], Body=pickle.dumps(centroids_df))
-        return centroids_df.shape, centroids_df.head(8)
-
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=1024)
-    iterdata = [f'{input_db["bucket"]}/{input_db["centroids"]}']
-    pw.map(store_centroids, iterdata)
-    centroids_shape, centroids_head = pw.get_result()
-    pw.clean()
-
-    return centroids_shape, centroids_head
 
 
 def calculate_centroids(config, input_db, formula_chunk_keys):
@@ -58,7 +23,7 @@ def calculate_centroids(config, input_db, formula_chunk_keys):
             return []
 
     def calculate_peaks_for_chunk(key, data_stream):
-        chunk_df = pd.read_pickle(data_stream, None)
+        chunk_df = pd.read_pickle(data_stream._raw_stream, None)
         peaks = [peak for formula_i, formula in chunk_df.formula.items()
                  for peak in calculate_peaks_for_formula(formula_i, formula)]
         peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
@@ -72,8 +37,8 @@ def calculate_centroids(config, input_db, formula_chunk_keys):
         peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
         return peaks_df
 
-    def merge_chunks_and_store(chunks, ibm_cos):
-        centroids_df = pd.concat(chunks).set_index('formula_i')
+    def merge_chunks_and_store(results, ibm_cos):
+        centroids_df = pd.concat(results).set_index('formula_i')
         ibm_cos.put_object(Bucket=input_db['bucket'], Key=input_db['centroids_pandas'], Body=pickle.dumps(centroids_df))
         return centroids_df.shape, centroids_df.head(8)
 
@@ -88,15 +53,15 @@ def calculate_centroids(config, input_db, formula_chunk_keys):
         'isocalc_sigma': 0.001238
     })
 
-    if False:
-        # TODO: Switch to this pywren codepath when cpyMSpec is in the runtime
+    if True:
+        # Change to false to calculate locally
         pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
         iterdata = [f'{input_db["bucket"]}/{chunk_key}' for chunk_key in formula_chunk_keys]
         futures = pw.map_reduce(calculate_peaks_for_chunk, iterdata, merge_chunks_and_store)
         centroids_shape, centroids_head = pw.get_result(futures)
         pw.clean()
     else:
-        ibm_cos = get_cos_client(config)
+        ibm_cos = get_ibm_cos_client(config)
 
         from concurrent.futures import ThreadPoolExecutor
         with ThreadPoolExecutor(max_workers=(os.cpu_count() or 1)) as ex:
@@ -155,14 +120,14 @@ def build_database(config, input_db, n_formula_chunks=256):
 
 
 def clean_formula_chunks(config, input_db, formula_chunk_keys):
-    ibm_cos = get_cos_client(config)
+    ibm_cos = get_ibm_cos_client(config)
     ibm_cos.delete_objects(Bucket=input_db['bucket'],
                            Delete={'Objects': [{'Key': key} for key in formula_chunk_keys]})
 
 
 def dump_mol_db(config, bucket, key, db_id, force=False):
     import requests
-    ibm_cos = get_cos_client(config)
+    ibm_cos = get_ibm_cos_client(config)
     try:
         ibm_cos.head_object(Bucket=bucket, Key=key)
         should_dump = force

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -1,7 +1,5 @@
 import logging
 
-from .dataset import read_dataset_coords, real_pixel_indices
-from .molecular_db import store_centroids_database
 from .dataset_segmentation import generate_segm_intervals, split_spectra_into_segments, clean_segments
 from .annotation import annotate_spectra, merge_annotation_results
 
@@ -10,18 +8,12 @@ logger = logging.getLogger(name='annotation_pipeline')
 
 def annotate_dataset(config, input_data, input_db, segm_n=256):
 
-    logger.info('Storing centroids database')
-    store_centroids_database(config, input_db)
-
-    spectra_coords = read_dataset_coords(config, input_data)
-    pixel_indices, nrows, ncols = real_pixel_indices(spectra_coords)
-
     logger.info('Generating segments')
     segm_intervals = generate_segm_intervals(config, input_db, segm_n)
     split_spectra_into_segments(config, input_data, segm_n, segm_intervals)
 
     logger.info('Annotating')
-    results = annotate_spectra(config, input_data, input_db, segm_n, pixel_indices, nrows, ncols)
+    results = annotate_spectra(config, input_data, input_db, segm_n)
     formula_scores_df, formula_images = merge_annotation_results(results)
 
     logger.info('Cleaning up')

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -19,9 +19,9 @@ def copy_local(cos_client, src, target_bucket, target_key):
 
 def copy_url(cos_client, url, target_bucket, target_key):
     print('Downloading {}'.format(url))
-    file = requests.get(url).json()['data']
+    file = requests.get(url)
     print('Copying to {}/{}'.format(target_bucket, target_key))
     cos_client.put_object(Bucket=target_bucket,
                           Key=target_key,
-                          Body=file.encode('utf-8'))
+                          Body=file._content)
     print('Copy completed for {}/{}'.format(target_bucket, target_key))

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -1,4 +1,5 @@
 import ibm_boto3
+import requests
 from ibm_botocore.client import Config
 
 
@@ -7,3 +8,20 @@ def get_ibm_cos_client(config):
                             ibm_api_key_id=config['ibm_cos']['api_key'],
                             config=Config(signature_version='oauth'),
                             endpoint_url=config['ibm_cos']['endpoint'])
+
+
+def copy_local(cos_client, src, target_bucket, target_key):
+    print('Copying from {} to {}/{}'.format(src, target_bucket, target_key))
+    with open(src, "rb") as fp:
+        cos_client.put_object(Bucket=target_bucket, Key=target_key, Body=fp)
+    print('Copy completed for {}/{}'.format(target_bucket, target_key))
+
+
+def copy_url(cos_client, url, target_bucket, target_key):
+    print('Downloading {}'.format(url))
+    file = requests.get(url).json()['data']
+    print('Copying to {}/{}'.format(target_bucket, target_key))
+    cos_client.put_object(Bucket=target_bucket,
+                          Key=target_key,
+                          Body=file.encode('utf-8'))
+    print('Copy completed for {}/{}'.format(target_bucket, target_key))

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -1,0 +1,9 @@
+import ibm_boto3
+from ibm_botocore.client import Config
+
+
+def get_ibm_cos_client(config):
+    return ibm_boto3.client(service_name='s3',
+                            ibm_api_key_id=config['ibm_cos']['api_key'],
+                            config=Config(signature_version='oauth'),
+                            endpoint_url=config['ibm_cos']['endpoint'])

--- a/input_config.json.template
+++ b/input_config.json.template
@@ -1,8 +1,33 @@
 {
   "dataset": {
     "bucket": "****",
-    "ds": "metabolomics/input/ds.txt",
-    "ds_coord": "metabolomics/input/ds_coord.txt",
+    "datasets": {
+      "local": {
+        "ds": "metabolomics/input/ds.txt",
+        "ds_coord": "metabolomics/input/ds_coord.txt",
+        "ds_path": "",
+        "ds_coord_path": ""
+      },
+      "small": {
+        "ds": "metabolomics/input/ds1.txt",
+        "ds_coord": "metabolomics/input/ds1_coord.txt",
+        "ds_link": "http://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-lachlan-public/metabolomics/input/ds5.txt",
+        "ds_coord_link": "http://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-lachlan-public/metabolomics/input/ds5_coord.txt"
+      },
+      "medium": {
+        "ds": "metabolomics/input/ds2.txt",
+        "ds_coord": "metabolomics/input/ds2_coord.txt",
+        "ds_link": "http://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-lachlan-public/metabolomics/input/ds3.txt",
+        "ds_coord_link": "http://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-lachlan-public/metabolomics/input/ds3_coord.txt"
+      },
+      "large": {
+        "ds": "metabolomics/input/ds3.txt",
+        "ds_coord": "metabolomics/input/ds3_coord.txt",
+        "ds_link": "http://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-lachlan-public/metabolomics/input/ds4.txt",
+        "ds_coord_link": "http://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-lachlan-public/metabolomics/input/ds4_coord.txt"
+      }
+    },
+    "ds_id": "local",
     "config": "metabolomics/data/config.json",
     "meta": "metabolomics/data/meta.json",
     "segments": "metabolomics/input/segments"

--- a/pywren-annotation-example-pipeline.ipynb
+++ b/pywren-annotation-example-pipeline.ipynb
@@ -203,9 +203,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Prints ds.txt size in COS\n",
+    "# Prints details of ds.txt to ensure that everything is correct\n",
     "key=input_data['datasets'][ds_id]['ds']\n",
-    "cos_client.get_object(Bucket=input_data['bucket'], Key=key)['Body']._content_length"
+    "cos_client.list_objects_v2(Bucket=input_db['bucket'], Prefix=key).get('Contents', [])"
    ]
   },
   {
@@ -214,9 +214,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Prints ds_coord.txt size in COS\n",
+    "# Prints details of ds_coords.txt to ensure that everything is correct\n",
     "key=input_data['datasets'][ds_id]['ds_coord']\n",
-    "cos_client.get_object(Bucket=input_data['bucket'], Key=key)['Body']._content_length"
+    "cos_client.list_objects_v2(Bucket=input_db['bucket'], Prefix=key).get('Contents', [])"
    ]
   },
   {
@@ -322,8 +322,8 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Prints centroids file size\n",
-    "cos_client.get_object(Bucket=input_db['bucket'], Key=input_db['centroids_pandas'])['Body']._content_length"
+    "# Prints details of centroids.pickle to ensure that everything is correct\n",
+    "cos_client.list_objects_v2(Bucket=input_db['bucket'], Prefix=input_db['centroids_pandas']).get('Contents', [])"
    ]
   },
   {
@@ -385,7 +385,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "# Prints details of pickled segments\n",
     "cos_client.list_objects_v2(Bucket=input_data['bucket'], Prefix=input_data['segments']).get('Contents', [])[:3]"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prints segments number in COS\n",
+    "cos_client.list_objects_v2(Bucket=input_data['bucket'], Prefix=input_data['segments'])['KeyCount']"
    ]
   },
   {

--- a/pywren-annotation-example-pipeline.ipynb
+++ b/pywren-annotation-example-pipeline.ipynb
@@ -163,7 +163,7 @@
     "### Input Dataset\n",
     "\n",
     "This part uploads input data from url or local path into IBM Cloud Object Storage.<br>\n",
-    "To upload dataset from local path, define `\"ds_id\": \"local\"` inside input config file."
+    "To upload dataset from local path, define `\"ds_id\": \"local\"` and specify files' paths inside input config file."
    ]
   },
   {

--- a/pywren-annotation-example-pipeline.ipynb
+++ b/pywren-annotation-example-pipeline.ipynb
@@ -4,37 +4,26 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Initial requirements\n",
+    "# Metaspace Annotation Pipeline on IBM Cloud\n",
+    "Experimental code to integrate Metaspace [engine](https://github.com/metaspace2020/metaspace/tree/master/metaspace/engine) with [PyWren](https://github.com/pywren/pywren-ibm-cloud) for IBM Cloud\n",
+    "\n",
+    "## Table of contents\n",
+    "1. [Follow Setup Instructions](#setup)\n",
+    "2. [Upload Data Files into IBM Cloud Object Storage](#upload)\n",
+    "3. [Split Dataset into Segments](#split)\n",
+    "4. [Apply Annotation to each Segment in Parallel](#annotation)\n",
+    "5. [Get Results](#results)\n",
+    "6. [Clean Segments Data in IBM Cloud Object Storage](#clean)"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# <a name=\"setup\"></a> 1. Follow Setup Instructions\n",
     "\n",
     "This notebook requires IBM Cloud Object Storage and IBM Cloud Functions\n",
     "Please follow IBM Cloud dashboard and create both services.\n"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# These are Python and Python lib path we want to use\n",
-    "import sys\n",
-    "sys.executable, sys.prefix"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Install PyWren-IBM if needed\n",
-    "try:\n",
-    "    import pywren_ibm_cloud as pywren\n",
-    "except ModuleNotFoundError:    \n",
-    "    !{sys.executable} -m pip install -U pywren-ibm-cloud==1.0.10\n",
-    "    import pywren_ibm_cloud as pywren\n",
-    "\n",
-    "pywren.__version__"
    ]
   },
   {
@@ -61,17 +50,10 @@
    "outputs": [],
    "source": [
     "%config Completer.use_jedi = False\n",
-    "%matplotlib inline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "%matplotlib inline\n",
     "%load_ext autoreload\n",
-    "%autoreload 2"
+    "%autoreload 2\n",
+    "import json"
    ]
   },
   {
@@ -80,26 +62,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from matplotlib import pyplot as plt\n",
-    "from scipy.sparse import coo_matrix\n",
-    "from collections import defaultdict\n",
-    "from pyImagingMSpec.image_measures import isotope_image_correlation, isotope_pattern_match\n",
-    "from cpyImagingMSpec import measure_of_chaos\n",
-    "from itertools import chain\n",
-    "from pathlib import Path\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import pickle\n",
-    "import sys\n",
-    "import io"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
+    "# Run this for DEBUG mode\n",
     "import logging\n",
     "logging.basicConfig(level=logging.DEBUG)"
    ]
@@ -108,13 +71,53 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### IBM COS Setup\n",
+    "### IBM Cloud PyWren Setup"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#Install PyWren-IBM if needed\n",
+    "import sys\n",
+    "try:\n",
+    "    import pywren_ibm_cloud as pywren\n",
+    "except ModuleNotFoundError:    \n",
+    "    !{sys.executable} -m pip install -U pywren-ibm-cloud==1.0.10\n",
+    "    import pywren_ibm_cloud as pywren\n",
     "\n",
-    "Copy the file `config.json.template` to `config.json` and fill in the missing values for API keys, buckets and endpoints per these instructions:\n",
+    "pywren.__version__"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "Copy the file `config.json.template` to `config.json` and fill in the missing values for API keys, buckets and endpoints per instructions below:"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "config = json.load(open('config.json'))"
+   ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "#### IBM Cloud Object Storage:\n",
     "\n",
     "Setup a bucket in IBM Cloud Object Storage\n",
     "\n",
     "You need an IBM COS bucket which you will use to store the input data. If you don't know of any of your existing buckets or would like like to create a new one, please navigate to your cloud resource list, then find and select your storage instance. From here, you will be able to view all your buckets and can create a new bucket in the region you prefer. Make sure you copy the correct endpoint for the bucket from the Endpoint tab of this COS service dashboard. Note: The bucket names must be unique.\n",
+    "\n",
+    "#### IBM Cloud Functions:\n",
     "\n",
     "Obtain the API key and endpoint to the IBM Cloud Functions service. Navigate to Getting Started > API Key from the side menu and copy the values for \"Current Namespace\", \"Host\" and \"Key\" into the config below. Make sure to add \"https://\" to the host when adding it as the endpoint."
    ]
@@ -125,18 +128,19 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import json\n",
-    "\n",
-    "config = json.load(open('config.json'))"
+    "from annotation_pipeline.utils import get_ibm_cos_client\n",
+    "cos_client = get_ibm_cos_client(config)"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Input Files Setup\n",
+    "### Data Files Setup\n",
     "\n",
-    "Copy the file `input_config.json.template` to `input_config.json` and fill in the missing values for buckets."
+    "Copy the file `input_config.json.template` to `input_config.json` and fill in the missing values for buckets.<br>\n",
+    "Change `\"ds_id\"` value to use different datasets (specify one of the datasets options).<br>\n",
+    "Change `\"modifiers\"` value to use different databases."
    ]
   },
   {
@@ -154,46 +158,12 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Upload test data into COS bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "import ibm_boto3\n",
-    "from ibm_botocore.client import Config\n",
-    "from ibm_botocore.client import ClientError"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "cos_client = ibm_boto3.client(service_name='s3',\n",
-    "                              ibm_api_key_id=config['ibm_cos']['api_key'],\n",
-    "#                               ibm_auth_endpoint=config['ibm_cos']['auth_endpoint'],\n",
-    "                              config=Config(signature_version='oauth'),\n",
-    "                              endpoint_url=config['ibm_cos']['endpoint'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "def copy(src, target_bucket, target_key):\n",
-    "    print('Copying from {} to {}/{}'.format(src, target_bucket, target_key))\n",
+    "# <a name='upload'></a> 2. Upload Data Files into IBM Cloud Object Storage\n",
     "\n",
-    "    with open(src, \"rb\") as fp:\n",
-    "        cos_client.put_object(Bucket=target_bucket, Key=target_key, Body=fp)\n",
+    "### Input Dataset\n",
     "\n",
-    "    print('Copy completed for {}/{}'.format(target_bucket, target_key))"
+    "This part uploads input data from url or local path into IBM Cloud Object Storage.<br>\n",
+    "To upload dataset from local path, define `\"ds_id\": \"local\"` inside input config file."
    ]
   },
   {
@@ -202,19 +172,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "import os\n",
-    "\n",
-    "for dirpath, dirnames, filenames in os.walk('./metabolomics'):\n",
-    "    for fn in filenames:\n",
-    "        f_path = f'{dirpath}/{fn}'\n",
-    "        copy(f_path, input_data['bucket'], f_path)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Read Dataset Spectra"
+    "# Specified database to be uploaded:\n",
+    "ds_id = input_data['ds_id']\n",
+    "ds_id"
    ]
   },
   {
@@ -223,141 +183,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.dataset import read_dataset_spectra, read_dataset_coords, real_pixel_indices"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spectra = read_dataset_spectra(config, input_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(spectra)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "sp_i, mzs, ints = spectra[0]\n",
-    "mzs"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "ints"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spectra_coords = read_dataset_coords(config, input_data)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "len(spectra_coords)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "spectra_coords[:5]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pixel_indices, nrows, ncols = real_pixel_indices(spectra_coords)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "pixel_indices"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "nrows, ncols"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "# Read Molecular Database and Store"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "from annotation_pipeline.molecular_db import process_formulas_database, store_centroids_database"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "formulas_shape, formulas_head = process_formulas_database(config, input_db)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "formulas_shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "formulas_head"
+    "from annotation_pipeline.dataset import dumb_input_dataset"
    ]
   },
   {
@@ -367,7 +193,8 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "centroids_shape, centroids_head = store_centroids_database(config, input_db)"
+    "# Downloads dataset from URL (or loads from local) and uploads (add force=True to reupload if needed)\n",
+    "dumb_input_dataset(config, input_data)"
    ]
   },
   {
@@ -376,7 +203,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "centroids_shape"
+    "# Prints ds.txt size in COS\n",
+    "key=input_data['datasets'][ds_id]['ds']\n",
+    "cos_client.get_object(Bucket=input_data['bucket'], Key=key)['Body']._content_length"
    ]
   },
   {
@@ -385,14 +214,28 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "centroids_head"
+    "# Prints ds_coord.txt size in COS\n",
+    "key=input_data['datasets'][ds_id]['ds_coord']\n",
+    "cos_client.get_object(Bucket=input_data['bucket'], Key=key)['Body']._content_length"
    ]
   },
   {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Generate Isotopic Peaks from Molecular Databases"
+    "### Generate Isotopic Peaks from Molecular Databases\n",
+    "\n",
+    "This part creates formulas in IBM Cloud Object Storage and then genrates and uploads centroids database."
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Specified modifiers to be used:\n",
+    "input_db['modifiers']"
    ]
   },
   {
@@ -474,10 +317,20 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Prints centroids file size\n",
+    "cos_client.get_object(Bucket=input_db['bucket'], Key=input_db['centroids_pandas'])['Body']._content_length"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Split Dataset into Segments"
+    "# <a name='split'></a> 3. Split Dataset into Segments"
    ]
   },
   {
@@ -522,6 +375,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "%%time\n",
     "split_spectra_into_segments(config, input_data, segm_n, segm_intervals)"
    ]
   },
@@ -538,7 +392,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Annotation Pipeline Applied to each Segment in Parallel"
+    "# <a name='annotation'></a> 4. Apply Annotation to each Segment in Parallel"
    ]
   },
   {
@@ -557,7 +411,7 @@
    "outputs": [],
    "source": [
     "%%time\n",
-    "results = annotate_spectra(config, input_data, input_db, segm_n, pixel_indices, nrows, ncols)"
+    "results = annotate_spectra(config, input_data, input_db, segm_n)"
    ]
   },
   {
@@ -573,7 +427,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Get Results"
+    "# <a name='results'></a> 5. Get Results"
    ]
   },
   {
@@ -596,12 +450,22 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "### Example"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
-    "img = formula_images[896952][0][1]\n",
+    "from matplotlib import pyplot as plt\n",
+    "for key, image_set in formula_images.items():\n",
+    "    img = image_set[0][1]\n",
+    "    break\n",
     "plt.imshow(img.toarray())"
    ]
   },
@@ -609,7 +473,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "## Clean Segments Datasets"
+    "# <a name='clean'></a> 6. Clean Segments Data in IBM Cloud Object Storage"
    ]
   },
   {
@@ -618,16 +482,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.dataset_segmentation import clean_segments"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "%%time\n",
+    "from annotation_pipeline.dataset_segmentation import clean_segments\n",
     "clean_segments(config, input_data)"
    ]
   }
@@ -648,7 +503,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.7"
+   "version": "3.6.0"
   }
  },
  "nbformat": 4,


### PR DESCRIPTION
This patch contains the following changes:

- add `utils.py` file for useful methods.
- `annotate_spectra` wrapper method now calls once for spectra coords without pywren (always only couple of bytes)
- remove all unnecessary examples methods
- add user-friendly method for download and upload datasets files (regarding input config file): now you can choose between 4 datasets - local, small, medium and large according to their size. if you choose local you can upload ds.txt and coords.txt directly from your computer (if needed) and if you choose the others, it will automatically download and upload with different keys in COS regarding to input config file.
- enable pywren for `calculate_centroids()` to work by default.
- restructure notebook to include ordered pipeline steps with instructions and to support the changes above.

Notice that you need to update `input_config.json` regarding the new template