### PR TITLE
match experimental notebooks for the recent changes

### DIFF
--- a/annotation_pipeline_v2/pipeline.py
+++ b/annotation_pipeline_v2/pipeline.py
@@ -101,6 +101,7 @@ class Pipeline(object):
         images = {}
         ibm_cos = get_ibm_cos_client(self.config)
         for segm_i in range(self.centr_segm_n):
+            logger.info(f'Downloading pickled images #{segm_i}')
             obj = ibm_cos.get_object(Bucket=self.config['storage']['output_bucket'],
                                      Key=f'{self.output["formula_images"]}/{segm_i}.pickle')
 

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -40,7 +40,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Notebook setup"
+    "# Notebook setup\n",
+    "Run `python3 setup.py install` to install all requirements for annotation pipeline project."
    ]
   },
   {
@@ -79,6 +80,28 @@
    },
    "outputs": [],
    "source": [
+    "# We need this to overcome Python notebooks limitations of too many open files\n",
+    "import resource\n",
+    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
+    "print('Before:', soft, hard)\n",
+    "\n",
+    "# Raising the soft limit. Hard limits can be raised only by sudo users\n",
+    "resource.setrlimit(resource.RLIMIT_NOFILE, (10000, hard))\n",
+    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
+    "print('After:', soft, hard)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "metadata": false,
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
     "# These are Python and Python lib path we want to use\n",
     "import sys\n",
     "sys.executable, sys.prefix"
@@ -95,7 +118,7 @@
    },
    "outputs": [],
    "source": [
-    "#Install PyWren-IBM if needed\n",
+    "# Install PyWren-IBM if needed\n",
     "try:\n",
     "    import pywren_ibm_cloud as pywren\n",
     "except ModuleNotFoundError:    \n",
@@ -117,55 +140,6 @@
     "except ModuleNotFoundError:    \n",
     "    !{sys.executable} -m pip install -U psutil\n",
     "    import psutil"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# We need this to overcome Python notebooks limitations of too many open files\n",
-    "import resource\n",
-    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
-    "print('Before:', soft, hard)\n",
-    "\n",
-    "# Raising the soft limit. Hard limits can be raised only by sudo users\n",
-    "resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))\n",
-    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
-    "print('After:', soft, hard)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "from scipy.sparse import coo_matrix\n",
-    "from collections import defaultdict\n",
-    "from pyImagingMSpec.image_measures import isotope_image_correlation, isotope_pattern_match\n",
-    "from cpyImagingMSpec import measure_of_chaos\n",
-    "from itertools import chain\n",
-    "from pathlib import Path\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import pickle\n",
-    "import sys\n",
-    "import io\n",
-    "import os\n",
-    "from datetime import datetime"
    ]
   },
   {
@@ -205,6 +179,7 @@
    },
    "outputs": [],
    "source": [
+    "import json\n",
     "config = json.load(open('config.json'))"
    ]
   },
@@ -219,35 +194,15 @@
    },
    "outputs": [],
    "source": [
-    "# input_config = json.load(open('metabolomics/input_config_small.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_small.json'))\n",
     "input_config = json.load(open('metabolomics/input_config_big.json'))\n",
-    "# input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']\n",
     "\n",
     "# Override config to match METASPACE annotation settings\n",
     "input_data['num_decoys'] = 20\n",
     "input_db['modifiers'] = ['']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import ibm_boto3\n",
-    "from ibm_botocore.client import Config\n",
-    "from ibm_botocore.client import ClientError\n",
-    "cos_client = ibm_boto3.client(service_name='s3',\n",
-    "                              ibm_api_key_id=config['ibm_cos']['api_key'],\n",
-    "                              config=Config(signature_version='oauth'),\n",
-    "                              endpoint_url=config['ibm_cos']['endpoint'])"
    ]
   },
   {
@@ -370,46 +325,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
     "start_time = datetime.now()\n",
     "print('start', start_time)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Upload dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from annotation_pipeline_v2.utils import upload_to_cos"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for root, dirnames, filenames in os.walk(input_data['path']):\n",
-    "    for fn in filenames:\n",
-    "        f_path = f'{root}/{fn}'\n",
-    "        print(f_path)\n",
-    "        upload_to_cos(cos_client, f_path, config['storage']['ds_bucket'], f_path)"
    ]
   },
   {
@@ -421,20 +339,6 @@
    },
    "source": [
     "### Run Annotation Pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true
-   },
-   "outputs": [],
-   "source": [
-    "# Download centroids.pickle to local machine\n",
-    "resp = cos_client.get_object(Bucket=config['storage']['db_bucket'], Key=input_db['centroids_pandas'])\n",
-    "with open(input_db['centroids_pandas'], 'wb') as f:\n",
-    "    f.write(resp['Body'].read())"
    ]
   },
   {
@@ -477,6 +381,15 @@
    "outputs": [],
    "source": [
     "%time pipeline.load_ds()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time pipeline.split_ds()"
    ]
   },
   {
@@ -701,18 +614,77 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Clean Temp Data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from annotation_pipeline_v2.utils import clean_from_cos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean dataset chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean dataset segments\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_segments\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids database segments\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_db[\"centroids_segments\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean formula output images\n",
+    "clean_from_cos(config, config[\"storage\"][\"output_bucket\"], output[\"formula_images\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean FDR rankings\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"fdr_rankings\"])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:sm]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-sm-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -724,7 +696,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.0"
   },
   "stem_cell": {
    "cell_type": "raw",

--- a/experiment-2-interactive.ipynb
+++ b/experiment-2-interactive.ipynb
@@ -30,7 +30,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Notebook setup"
+    "# Notebook setup\n",
+    "Run `python3 setup.py install` to install all requirements for annotation pipeline project."
    ]
   },
   {
@@ -56,6 +57,28 @@
    "source": [
     "%config Completer.use_jedi = False\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "metadata": false,
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# We need this to overcome Python notebooks limitations of too many open files\n",
+    "import resource\n",
+    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
+    "print('Before:', soft, hard)\n",
+    "\n",
+    "# Raising the soft limit. Hard limits can be raised only by sudo users\n",
+    "resource.setrlimit(resource.RLIMIT_NOFILE, (10000, hard))\n",
+    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
+    "print('After:', soft, hard)"
    ]
   },
   {
@@ -106,55 +129,6 @@
    },
    "outputs": [],
    "source": [
-    "# We need this to overcome Python notebooks limitations of too many open files\n",
-    "import resource\n",
-    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
-    "print('Before:', soft, hard)\n",
-    "\n",
-    "# Raising the soft limit. Hard limits can be raised only by sudo users\n",
-    "resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))\n",
-    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
-    "print('After:', soft, hard)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "from scipy.sparse import coo_matrix\n",
-    "from collections import defaultdict\n",
-    "from pyImagingMSpec.image_measures import isotope_image_correlation, isotope_pattern_match\n",
-    "from cpyImagingMSpec import measure_of_chaos\n",
-    "from itertools import chain\n",
-    "from pathlib import Path\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import pickle\n",
-    "import sys\n",
-    "import io\n",
-    "import os\n",
-    "from datetime import datetime"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
     "import logging\n",
     "logging.basicConfig(level=logging.INFO)"
    ]
@@ -181,6 +155,7 @@
    },
    "outputs": [],
    "source": [
+    "import json\n",
     "config = json.load(open('config.json'))"
    ]
   },
@@ -195,9 +170,9 @@
    },
    "outputs": [],
    "source": [
-    "# input_config = json.load(open('metabolomics/input_config_small.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_small.json'))\n",
     "input_config = json.load(open('metabolomics/input_config_big.json'))\n",
-    "# input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']\n",
     "\n",
@@ -207,62 +182,10 @@
    ]
   },
   {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import ibm_boto3\n",
-    "from ibm_botocore.client import Config\n",
-    "from ibm_botocore.client import ClientError\n",
-    "cos_client = ibm_boto3.client(service_name='s3',\n",
-    "                              ibm_api_key_id=config['ibm_cos']['api_key'],\n",
-    "                              config=Config(signature_version='oauth'),\n",
-    "                              endpoint_url=config['ibm_cos']['endpoint'])"
-   ]
-  },
-  {
    "cell_type": "markdown",
    "metadata": {},
    "source": [
     "# Initial setup (not included in benchmark timings)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {
-    "heading_collapsed": true,
-    "pycharm": {
-     "metadata": false
-    }
-   },
-   "source": [
-    "### Upload test data into COS bucket"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from annotation_pipeline_v2.utils import upload_to_cos\n",
-    "for root, dirnames, filenames in os.walk(input_data['path']):\n",
-    "    for fn in filenames:\n",
-    "        f_path = f'{root}/{fn}'\n",
-    "        print(f_path)\n",
-    "        upload_to_cos(cos_client, f_path, config['storage']['ds_bucket'], f_path)"
    ]
   },
   {
@@ -281,6 +204,7 @@
     "from annotation_pipeline_v2.pipeline import Pipeline\n",
     "pipeline = Pipeline(config, input_config)\n",
     "pipeline.load_ds()\n",
+    "pipeline.split_ds()\n",
     "pipeline.segment_ds()"
    ]
   },
@@ -302,6 +226,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
     "start_time = datetime.now()\n",
     "print('start', start_time)"
    ]
@@ -335,6 +260,7 @@
    "outputs": [],
    "source": [
     "# Upload list of molecules (in a real scenario this list would change every iteration, so this isn't part of setup)\n",
+    "import pandas as pd\n",
     "mols = pd.read_csv('metabolomics/db/mol_db5.csv')\n",
     "mols_list = sorted(set(mols.sf.values.tolist()))\n",
     "cos_client.put_object(Bucket=config['storage']['db_bucket'], Key=exp_db_path, Body=pickle.dumps(mols_list))"
@@ -371,20 +297,6 @@
     "polarity = input_data['polarity']\n",
     "isocalc_sigma = input_data['isocalc_sigma']\n",
     "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true
-   },
-   "outputs": [],
-   "source": [
-    "# Download centroids.pickle to local machine (Can be removed when pipeline can run directly from COS)\n",
-    "resp = cos_client.get_object(Bucket=config['storage']['db_bucket'], Key=input_db['centroids_pandas'])\n",
-    "with open(input_db['centroids_pandas'], 'wb') as f:\n",
-    "    f.write(resp['Body'].read())"
    ]
   },
   {
@@ -464,13 +376,79 @@
     "print('finish', finish_time)\n",
     "print('duration', finish_time - start_time)"
    ]
+  },
+  {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Clean Temp Data"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "from annotation_pipeline_v2.utils import clean_from_cos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean dataset chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean dataset segments\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_segments\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids database segments\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_db[\"centroids_segments\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean formula output images\n",
+    "clean_from_cos(config, config[\"storage\"][\"output_bucket\"], output[\"formula_images\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean FDR rankings\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"fdr_rankings\"])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:sm]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-sm-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -482,7 +460,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.0"
   },
   "stem_cell": {
    "cell_type": "raw",

--- a/experiment-3-large.ipynb
+++ b/experiment-3-large.ipynb
@@ -22,7 +22,8 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Notebook setup"
+    "# Notebook setup\n",
+    "Run python3 setup.py install to install all requirements for annotation pipeline project."
    ]
   },
   {
@@ -48,6 +49,28 @@
    "source": [
     "%config Completer.use_jedi = False\n",
     "%matplotlib inline"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {
+    "pycharm": {
+     "metadata": false,
+     "name": "#%%\n"
+    }
+   },
+   "outputs": [],
+   "source": [
+    "# We need this to overcome Python notebooks limitations of too many open files\n",
+    "import resource\n",
+    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
+    "print('Before:', soft, hard)\n",
+    "\n",
+    "# Raising the soft limit. Hard limits can be raised only by sudo users\n",
+    "resource.setrlimit(resource.RLIMIT_NOFILE, (10000, hard))\n",
+    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
+    "print('After:', soft, hard)"
    ]
   },
   {
@@ -98,55 +121,6 @@
    },
    "outputs": [],
    "source": [
-    "# We need this to overcome Python notebooks limitations of too many open files\n",
-    "import resource\n",
-    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
-    "print('Before:', soft, hard)\n",
-    "\n",
-    "# Raising the soft limit. Hard limits can be raised only by sudo users\n",
-    "resource.setrlimit(resource.RLIMIT_NOFILE, (hard, hard))\n",
-    "soft, hard = resource.getrlimit(resource.RLIMIT_NOFILE)\n",
-    "print('After:', soft, hard)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from matplotlib import pyplot as plt\n",
-    "from scipy.sparse import coo_matrix\n",
-    "from collections import defaultdict\n",
-    "from pyImagingMSpec.image_measures import isotope_image_correlation, isotope_pattern_match\n",
-    "from cpyImagingMSpec import measure_of_chaos\n",
-    "from itertools import chain\n",
-    "from pathlib import Path\n",
-    "import numpy as np\n",
-    "import pandas as pd\n",
-    "import pickle\n",
-    "import sys\n",
-    "import io\n",
-    "import os\n",
-    "from datetime import datetime"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
     "import logging\n",
     "logging.basicConfig(level=logging.INFO)"
    ]
@@ -173,6 +147,7 @@
    },
    "outputs": [],
    "source": [
+    "import json\n",
     "config = json.load(open('config.json'))"
    ]
   },
@@ -188,30 +163,10 @@
    "outputs": [],
    "source": [
     "input_config = json.load(open('metabolomics/input_config_small.json'))\n",
-    "# input_config = json.load(open('metabolomics/input_config_big.json'))\n",
-    "# input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_big.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "import ibm_boto3\n",
-    "from ibm_botocore.client import Config\n",
-    "from ibm_botocore.client import ClientError\n",
-    "cos_client = ibm_boto3.client(service_name='s3',\n",
-    "                              ibm_api_key_id=config['ibm_cos']['api_key'],\n",
-    "                              config=Config(signature_version='oauth'),\n",
-    "                              endpoint_url=config['ibm_cos']['endpoint'])"
    ]
   },
   {
@@ -232,46 +187,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
+    "from datetime import datetime\n",
     "start_time = datetime.now()\n",
     "print('start', start_time)"
-   ]
-  },
-  {
-   "cell_type": "markdown",
-   "metadata": {},
-   "source": [
-    "### Upload dataset"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true
-   },
-   "outputs": [],
-   "source": [
-    "import os\n",
-    "from annotation_pipeline_v2.utils import upload_to_cos"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "for root, dirnames, filenames in os.walk(input_data['path']):\n",
-    "    for fn in filenames:\n",
-    "        f_path = f'{root}/{fn}'\n",
-    "        print(f_path)\n",
-    "        upload_to_cos(cos_client, f_path, config['storage']['ds_bucket'], f_path)"
    ]
   },
   {
@@ -379,20 +297,6 @@
    "cell_type": "code",
    "execution_count": null,
    "metadata": {
-    "hidden": true
-   },
-   "outputs": [],
-   "source": [
-    "# Download centroids.pickle to local machine\n",
-    "resp = cos_client.get_object(Bucket=config['storage']['db_bucket'], Key=input_db['centroids_pandas'])\n",
-    "with open(input_db['centroids_pandas'], 'wb') as f:\n",
-    "    f.write(resp['Body'].read())"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
     "pycharm": {
      "metadata": false,
      "name": "#%%\n"
@@ -429,6 +333,15 @@
    "outputs": [],
    "source": [
     "%time pipeline.load_ds()"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "%time pipeline.split_ds()"
    ]
   },
   {
@@ -510,18 +423,77 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# Clean Temp Data"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
    "outputs": [],
-   "source": []
+   "source": [
+    "from annotation_pipeline_v2.utils import clean_from_cos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean dataset chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean dataset segments\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_segments\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids database segments\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_db[\"centroids_segments\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean formula output images\n",
+    "clean_from_cos(config, config[\"storage\"][\"output_bucket\"], output[\"formula_images\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean FDR rankings\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"fdr_rankings\"])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:sm]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-sm-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -533,7 +505,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.0"
   },
   "stem_cell": {
    "cell_type": "raw",

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -1,7 +1,7 @@
 {
   "dataset": {
     "path": "metabolomics/ds/AZ_Rat_brains",
-    "ds_chunks": "metabolomics/tmp/ds_chunks",
+    "ds_chunks": "metabolomics/tmp/ds_chunks/AZ_Rat_brains",
     "ds_segments": "metabolomics/tmp/ds_segments",
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -1,7 +1,7 @@
 {
   "dataset": {
     "path": "metabolomics/ds/CT26_xenograft",
-    "ds_chunks": "metabolomics/tmp/ds_chunks",
+    "ds_chunks": "metabolomics/tmp/ds_chunks/CT26_xenograft",
     "ds_segments": "metabolomics/tmp/ds_segments",
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -1,7 +1,7 @@
 {
   "dataset": {
     "path": "metabolomics/ds/Brain02_Bregma1-42_02",
-    "ds_chunks": "metabolomics/tmp/ds_chunks",
+    "ds_chunks": "metabolomics/tmp/ds_chunks/Brain02_Bregma1-42_02",
     "ds_segments": "metabolomics/tmp/ds_segments",
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,

--- a/pywren-annotation-pipeline-v2.ipynb
+++ b/pywren-annotation-pipeline-v2.ipynb
@@ -656,13 +656,23 @@
     "# Clean formula output images\n",
     "clean_from_cos(config, config[\"storage\"][\"output_bucket\"], output[\"formula_images\"])"
    ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean FDR rankings\n",
+    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"fdr_rankings\"])"
+   ]
   }
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python [conda env:sm]",
+   "display_name": "Python 3",
    "language": "python",
-   "name": "conda-env-sm-py"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -674,7 +684,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.8"
+   "version": "3.6.0"
   },
   "stem_cell": {
    "cell_type": "raw",


### PR DESCRIPTION
**changes**:
- add different tagging for dataset chunks in COS for each dataset for convenience purposes - now we don't have to run this part every time, we can skip it after run it once (for fast experiments).
- add split dataset method from `Pipeline` class to each experimental notebook.
- remove the part that uploads the entire dataset to COS from all experimental notebooks - not needed for now because the split is done locally.
- remove the part that downloads the centroids database into local machine - not needed.
- add a part that cleans temp data in COS at the end of each notebook.