### PR TITLE
Fix memory issues when databases are created

### DIFF
--- a/annotation_pipeline/__main__.py
+++ b/annotation_pipeline/__main__.py
@@ -44,14 +44,14 @@ def generate_centroids(args, config):
     dump_mol_db(config, config['storage']['db_bucket'], f'{databases_path}/mol_db3.pickle', 24)  # LipidMaps-2017-12-12
     dump_mol_db(config, config['storage']['db_bucket'], f'{databases_path}/mol_db4.pickle', 26)  # SwissLipids-2018-02-02
 
-    num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)
+    num_formulas, n_formulas_chunks = build_database(config, input_db)
     logger.info(f'Number of formulas: {num_formulas}')
     # Use '+' if missing from the config, but it's better to get the actual value as it affects the results
     polarity = input_data['polarity']
     # Use 0.001238 if missing from the config, but it's better to get the actual value as it affects the results
     isocalc_sigma = input_data['isocalc_sigma']
-    centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)
-    logger.info(f'Number of centroids generated: {centroids_shape[0]}')
+    num_centroids, n_centroids_chunks = calculate_centroids(config, input_db, polarity, isocalc_sigma)
+    logger.info(f'Number of centroids generated: {num_centroids}')
 
 
 def convert_imzml(args, config):
@@ -118,10 +118,10 @@ if __name__ == '__main__':
     annotate_parser.add_argument('output', default='output', nargs='?', help='directory to write output files')
     annotate_parser.add_argument('--no-output', action="store_true", help='prevents outputs from being written to file')
 
-    annotate_parser = subparsers.add_parser('generate_centroids')
-    annotate_parser.set_defaults(func=generate_centroids)
-    annotate_parser.add_argument('input', type=argparse.FileType('r'), default='input_config.json', nargs='?',
-                                 help='input_config.json path')
+    centroids_parser = subparsers.add_parser('generate_centroids')
+    centroids_parser.set_defaults(func=generate_centroids)
+    centroids_parser.add_argument('input', type=argparse.FileType('r'), default='input_config.json', nargs='?',
+                                  help='input_config.json path')
 
     convert_parser = subparsers.add_parser('convert_imzml')
     convert_parser.set_defaults(func=convert_imzml)

--- a/annotation_pipeline/__main__.py
+++ b/annotation_pipeline/__main__.py
@@ -69,12 +69,12 @@ def convert_imzml(args, config):
         imzml_filename = input_key_imzml.split('/')[-1]
         imzml_path = str(Path(temp_dir.name) / imzml_filename)
 
-        logger.debug('download_file', input_bucket, input_key_imzml, imzml_path)
+        logger.info('download_file', input_bucket, input_key_imzml, imzml_path)
         ibm_cos.download_file(input_bucket, input_key_imzml, imzml_path)
 
         input_key_ibd = input_key_imzml[:-6] + '.ibd'
         ibd_path = imzml_path[:-6] + '.ibd'
-        logger.debug('download_file', input_bucket, input_key_ibd, ibd_path)
+        logger.info('download_file', input_bucket, input_key_ibd, ibd_path)
         ibm_cos.download_file(input_bucket, input_key_ibd, ibd_path)
     else:
         imzml_path = args.input
@@ -89,17 +89,17 @@ def convert_imzml(args, config):
     coord_path = spectra_path[:-4] + '_coord.txt'
 
     logger.info('Converting to txt')
-    logger.debug('convert_imzml_to_txt', imzml_path, spectra_path, coord_path)
+    logger.info('convert_imzml_to_txt', imzml_path, spectra_path, coord_path)
     convert_imzml_to_txt(imzml_path, spectra_path, coord_path)
 
     # Upload output if using COS
     if args.cos_output:
         logger.info('Uploading output files')
-        logger.debug('upload_file', output_bucket, output_key, spectra_path)
+        logger.info('upload_file', output_bucket, output_key, spectra_path)
         ibm_cos.upload_file(spectra_path, output_bucket, output_key)
 
         output_key_coord = output_key[:-4] + '_coord.txt'
-        logger.debug('upload_file', output_bucket, output_key_coord, coord_path)
+        logger.info('upload_file', output_bucket, output_key_coord, coord_path)
         ibm_cos.upload_file(coord_path, output_bucket, output_key_coord)
 
 

--- a/annotation_pipeline/__main__.py
+++ b/annotation_pipeline/__main__.py
@@ -44,7 +44,7 @@ def generate_centroids(args, config):
     dump_mol_db(config, config['storage']['db_bucket'], f'{databases_path}/mol_db3.pickle', 24)  # LipidMaps-2017-12-12
     dump_mol_db(config, config['storage']['db_bucket'], f'{databases_path}/mol_db4.pickle', 26)  # SwissLipids-2018-02-02
 
-    num_formulas, formula_chunk_keys = build_database(config, input_db)
+    num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)
     logger.info(f'Number of formulas: {num_formulas}')
     # Use '+' if missing from the config, but it's better to get the actual value as it affects the results
     polarity = input_data['polarity']

--- a/annotation_pipeline/__main__.py
+++ b/annotation_pipeline/__main__.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from annotation_pipeline.utils import get_ibm_cos_client
 from annotation_pipeline.imzml import convert_imzml_to_txt
 from annotation_pipeline.pipeline import Pipeline
-from annotation_pipeline.molecular_db import dump_mol_db, build_database, calculate_centroids, clean_formula_chunks
+from annotation_pipeline.molecular_db import dump_mol_db, build_database, calculate_centroids
 
 logger = logging.getLogger(name='annotation_pipeline')
 

--- a/annotation_pipeline/fdr.py
+++ b/annotation_pipeline/fdr.py
@@ -64,7 +64,6 @@ def build_fdr_rankings(config, input_data, input_db, formula_scores_df):
     futures = pw.map(build_ranking, [(formula_to_id_path, job_i, *job) for job_i, job in enumerate(ranking_jobs)])
     ranking_keys = [key for job_i, key in sorted(pw.get_result(futures))]
     append_pywren_stats(build_ranking.__name__, 2048, futures)
-    pw.clean()
 
     rankings_df = pd.DataFrame(ranking_jobs, columns=['group_i', 'ranking_i', 'database_path', 'modifier', 'adduct'])
     rankings_df = rankings_df.assign(is_target=~rankings_df.adduct.isnull(), key=ranking_keys)
@@ -116,6 +115,5 @@ def calculate_fdrs(config, input_data, rankings_df):
     futures = pw.map(merge_rankings, ranking_jobs)
     results = pw.get_result(futures)
     append_pywren_stats(merge_rankings.__name__, 2048, futures)
-    pw.clean()
 
     return pd.concat(results)

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -11,9 +11,15 @@ from annotation_pipeline.utils import get_ibm_cos_client, append_pywren_stats, c
 
 
 DECOY_ADDUCTS = ['+He', '+Li', '+Be', '+B', '+C', '+N', '+O', '+F', '+Ne', '+Mg', '+Al', '+Si', '+P', '+S', '+Cl', '+Ar', '+Ca', '+Sc', '+Ti', '+V', '+Cr', '+Mn', '+Fe', '+Co', '+Ni', '+Cu', '+Zn', '+Ga', '+Ge', '+As', '+Se', '+Br', '+Kr', '+Rb', '+Sr', '+Y', '+Zr', '+Nb', '+Mo', '+Ru', '+Rh', '+Pd', '+Ag', '+Cd', '+In', '+Sn', '+Sb', '+Te', '+I', '+Xe', '+Cs', '+Ba', '+La', '+Ce', '+Pr', '+Nd', '+Sm', '+Eu', '+Gd', '+Tb', '+Dy', '+Ho', '+Ir', '+Th', '+Pt', '+Os', '+Yb', '+Lu', '+Bi', '+Pb', '+Re', '+Tl', '+Tm', '+U', '+W', '+Au', '+Er', '+Hf', '+Hg', '+Ta']
+NUM_FORMULAS_CHUNKS = 256
 
 
-def calculate_centroids(config, input_db, formula_chunk_keys, polarity='+', isocalc_sigma=0.001238):
+def calculate_centroids(config, input_db, polarity='+', isocalc_sigma=0.001238, n_formulas_chunks=NUM_FORMULAS_CHUNKS):
+    bucket = config["storage"]["db_bucket"]
+    formulas_chunks_prefix = input_db["formulas_chunks"]
+    centroids_chunks_prefix = input_db["centroids_chunks"]
+    clean_from_cos(config, bucket, centroids_chunks_prefix)
+
     def calculate_peaks_for_formula(formula_i, formula):
         mzs, ints = isocalc_wrapper.centroids(formula)
         if mzs is not None:
@@ -21,17 +27,15 @@ def calculate_centroids(config, input_db, formula_chunk_keys, polarity='+', isoc
         else:
             return []
 
-    def calculate_peaks_for_chunk(key, data_stream):
+    def calculate_peaks_for_chunk(key, data_stream, chunk_i, ibm_cos):
         chunk_df = pd.read_pickle(data_stream._raw_stream, None)
         peaks = [peak for formula_i, formula in chunk_df.formula.items()
                  for peak in calculate_peaks_for_formula(formula_i, formula)]
         peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
-        return peaks_df
+        peaks_df.set_index('formula_i')
 
-    def merge_chunks_and_store(results, ibm_cos):
-        centroids_df = pd.concat(results).set_index('formula_i')
-        ibm_cos.put_object(Bucket=config['storage']['db_bucket'], Key=input_db['centroids_pandas'], Body=pickle.dumps(centroids_df))
-        return centroids_df.shape, centroids_df.head(8)
+        centroids_chunk_key = f'{centroids_chunks_prefix}/{chunk_i}.pickle'
+        ibm_cos.put_object(Bucket=bucket, Key=centroids_chunk_key, Body=pickle.dumps(peaks_df))
 
     from annotation_pipeline.isocalc_wrapper import IsocalcWrapper # Import lazily so that the rest of the pipeline still works if the dependency is missing
     isocalc_wrapper = IsocalcWrapper({
@@ -45,32 +49,18 @@ def calculate_centroids(config, input_db, formula_chunk_keys, polarity='+', isoc
     })
 
     pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
-    iterdata = [f'{config["storage"]["db_bucket"]}/{chunk_key}' for chunk_key in formula_chunk_keys]
-    futures = pw.map_reduce(calculate_peaks_for_chunk, iterdata, merge_chunks_and_store)
-    centroids_shape, centroids_head = pw.get_result(futures)
-    append_pywren_stats(calculate_peaks_for_chunk.__name__, 2048, futures[:-1])
-    append_pywren_stats(merge_chunks_and_store.__name__, 2048, futures[-1])
-    pw.clean()
-
-    return centroids_shape, centroids_head
+    iterdata = [[f'{bucket}/{formulas_chunks_prefix}/{chunk_i}.pickle', chunk_i] for chunk_i in range(n_formulas_chunks)]
+    futures = pw.map(calculate_peaks_for_chunk, iterdata)
+    pw.get_result(futures)
+    append_pywren_stats(calculate_peaks_for_chunk.__name__, 2048, futures)
 
 
-def get_formulas(config, ibm_cos, formula_keys):
-    def get_formula_stream(formula_key):
-        return pickle.loads(ibm_cos.get_object(Bucket=config['storage']['db_bucket'], Key=formula_key)['Body'].read())
+def build_database(config, input_db, n_formulas_chunks=NUM_FORMULAS_CHUNKS):
+    bucket = config["storage"]["db_bucket"]
+    formulas_chunks_prefix = input_db["formulas_chunks"]
+    clean_from_cos(config, bucket, formulas_chunks_prefix)
 
-    with ThreadPoolExecutor(max_workers=128) as pool:
-        results = list(pool.map(get_formula_stream, formula_keys))
-
-    # Reduce list of formulas for processing to include only unique formulas
-    formulas = pd.DataFrame(sorted(set().union(*results)), columns=['formula'])
-    formulas.index.name = 'formula_i'
-    return formulas
-
-
-def build_database(config, input_db, n_formula_chunks=256):
-    def generate_formulas(key, data_stream, formula_i, data, ibm_cos):
-        adducts, modifiers = data
+    def generate_formulas(key, data_stream, adducts, modifiers):
         mols = pickle.loads(data_stream.read())
         formulas = set()
 
@@ -80,63 +70,60 @@ def build_database(config, input_db, n_formula_chunks=256):
 
         if None in formulas:
             formulas.remove(None)
+        return formulas
 
-        formula_key = f'{input_db["formulas_chunks"]}_temp/{formula_i}.pickle'
-        ibm_cos.put_object(Bucket=config['storage']['db_bucket'], Key=formula_key, Body=pickle.dumps(formulas))
-        return formula_key
-
-    def store_formulas(formula_keys, ibm_cos):
-        formulas = get_formulas(config, ibm_cos, formula_keys)
-        num_chunks = min(len(formulas), n_formula_chunks)
-        chunk_keys = []
+    def store_formulas(results, ibm_cos):
+        # Reduce list of formulas for processing to include only unique formulas
+        formulas = pd.DataFrame(sorted(set().union(*results)), columns=['formula'])
+        formulas.index.name = 'formula_i'
+        num_chunks = min(len(formulas), n_formulas_chunks)
 
         # Write pickled chunks equivalent to formulas.csv with (formula_i, formula)
-        for i in range(num_chunks):
-            lo = len(formulas) * i // num_chunks
-            hi = len(formulas) * (i + 1) // num_chunks
-            chunk_key = f'{input_db["formulas_chunks"]}/{i}.pickle'
-            chunk_keys.append(chunk_key)
+        def _store(formula_chunk_i):
+            lo = len(formulas) * formula_chunk_i // num_chunks
+            hi = len(formulas) * (formula_chunk_i + 1) // num_chunks
+            chunk_key = f'{formulas_chunks_prefix}/{formula_chunk_i}.pickle'
             chunk = pd.DataFrame(formulas.formula[lo:hi], copy=True)
             chunk.index.name = 'formula_i'
 
-            ibm_cos.put_object(Bucket=config['storage']['db_bucket'], Key=chunk_key,
-                               Body=pickle.dumps(chunk))
+            ibm_cos.put_object(Bucket=bucket, Key=chunk_key, Body=pickle.dumps(chunk))
 
-        return len(formulas), chunk_keys
+        with ThreadPoolExecutor(max_workers=128) as pool:
+            pool.map(_store, range(num_chunks))
+
+        return len(formulas)
 
     adducts = [*input_db['adducts'], *DECOY_ADDUCTS]
     modifiers = input_db['modifiers']
     databases = input_db['databases']
 
     pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
+    iterdata = [(f'{bucket}/{database}', [adduct], modifiers) for database in databases for adduct in adducts]
+    futures = pw.map_reduce(generate_formulas, iterdata, store_formulas)
+    num_formulas = pw.get_result(futures)
+    append_pywren_stats(generate_formulas.__name__, 2048, futures[:-1])
+    append_pywren_stats(store_formulas.__name__, 2048, futures[-1])
 
-    iterdata = [(database, [adduct], modifiers) for database in databases for adduct in adducts]
-    iterdata = [(f'{config["storage"]["db_bucket"]}/{database}', i, (adducts, modifiers))
-                for i, (database, adducts, modifiers) in enumerate(iterdata)]
-    futures = pw.map(generate_formulas, iterdata)
-    formula_keys = pw.get_result(futures)
-    append_pywren_stats(generate_formulas.__name__, 2048, futures)
-
-    futures = pw.map(store_formulas, [[formula_keys]])
-    num_formulas, formula_chunk_keys = pw.get_result(futures)
-    append_pywren_stats(store_formulas.__name__, 2048, futures)
-
-    return num_formulas, formula_keys, formula_chunk_keys
+    return num_formulas
 
 
-def get_formula_id_dfs(config, formula_keys):
+def get_formula_id_dfs(config, input_db, n_formulas_chunks=NUM_FORMULAS_CHUNKS):
     ibm_cos = get_ibm_cos_client(config)
-    formulas = get_formulas(config, ibm_cos, formula_keys)
+    bucket = config["storage"]["db_bucket"]
+    formulas_chunks_prefix = input_db["formulas_chunks"]
+
+    def get_formula_chunk(formula_chunk_key):
+        return pickle.loads(ibm_cos.get_object(Bucket=config['storage']['db_bucket'], Key=formula_chunk_key)['Body'].read())
+
+    with ThreadPoolExecutor(max_workers=128) as pool:
+        iterdata = [f'{bucket}/{formulas_chunks_prefix}/{chunk_i}.pickle' for chunk_i in range(n_formulas_chunks)]
+        results = list(pool.map(get_formula_chunk, iterdata))
+
+    formulas = pd.concat(results)
     formula_to_id = dict(zip(formulas.formula, formulas.index))
     id_to_formula = formulas.formula.to_dict()
 
     return formula_to_id, id_to_formula
-
-
-def clean_formula_chunks(config, input_db, formula_chunk_keys):
-    ibm_cos = get_ibm_cos_client(config)
-    ibm_cos.delete_objects(Bucket=config['storage']['db_bucket'],
-                           Delete={'Objects': [{'Key': key} for key in formula_chunk_keys]})
 
 
 def dump_mol_db(config, bucket, key, db_id, force=False):

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -32,7 +32,7 @@ def calculate_centroids(config, input_db, polarity='+', isocalc_sigma=0.001238, 
         peaks = [peak for formula_i, formula in chunk_df.formula.items()
                  for peak in calculate_peaks_for_formula(formula_i, formula)]
         peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
-        peaks_df.set_index('formula_i')
+        peaks_df.set_index('formula_i', inplace=True)
 
         centroids_chunk_key = f'{centroids_chunks_prefix}/{chunk_i}.msgpack'
         ibm_cos.put_object(Bucket=bucket, Key=centroids_chunk_key, Body=peaks_df.to_msgpack())

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -64,8 +64,7 @@ class Pipeline(object):
         mz_min, mz_max = self.ds_segments_bounds[0, 0], self.ds_segments_bounds[-1, 1]
         self.centr_n, self.centr_segm_n = segment_centroids(self.config, self.config["storage"]["db_bucket"],
                                                             self.input_db["centroids_chunks"],
-                                                            self.input_db["centroids_segments"],
-                                                            self.input_db["centroids_df"], mz_min, mz_max,
+                                                            self.input_db["centroids_segments"], mz_min, mz_max,
                                                             self.ds_segm_n, self.ds_segm_size_mb)
 
     def annotate(self):

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -38,7 +38,7 @@ def clean_from_cos(config, bucket, prefix):
         keys = [obj['Key'] for obj in objs['Contents']]
         formatted_keys = {'Objects': [{'Key': key} for key in keys]}
         cos_client.delete_objects(Bucket=bucket, Delete=formatted_keys)
-        logger.debug(f'Removed {objs["KeyCount"]} objects from {prefix}')
+        logger.info(f'Removed {objs["KeyCount"]} objects from {prefix}')
         objs = cos_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
 
 

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -260,7 +260,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas, formula_chunk_keys = build_database(config, input_db)"
+    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)"
    ]
   },
   {
@@ -292,7 +292,7 @@
    },
    "outputs": [],
    "source": [
-    "clean_formula_chunks(config, input_db, formula_chunk_keys)"
+    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
    ]
   },
   {

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -225,7 +225,7 @@
    "outputs": [],
    "source": [
     "from annotation_pipeline.molecular_db import dump_mol_db, build_database, \\\n",
-    "    calculate_centroids, get_formula_id_dfs, clean_formula_chunks"
+    "    calculate_centroids, get_formula_id_dfs"
    ]
   },
   {
@@ -260,7 +260,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)"
+    "build_database(config, input_db)"
    ]
   },
   {
@@ -277,22 +277,7 @@
    "source": [
     "polarity = input_data['polarity']\n",
     "isocalc_sigma = input_data['isocalc_sigma']\n",
-    "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
+    "calculate_centroids(config, input_db, polarity, isocalc_sigma)"
    ]
   },
   {
@@ -579,6 +564,26 @@
    "outputs": [],
    "source": [
     "from annotation_pipeline.utils import clean_from_cos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean formulas chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"formulas_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
    ]
   },
   {

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -582,16 +582,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Clean centroids chunks\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Clean dataset chunks\n",
     "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_chunks\"])"
    ]

--- a/experiment-2-interactive.ipynb
+++ b/experiment-2-interactive.ipynb
@@ -272,10 +272,10 @@
     "mols = pd.read_csv('metabolomics/db/mol_db5.csv')\n",
     "mols_list = sorted(set(mols.sf.values.tolist()))\n",
     "cos_client.put_object(Bucket=config['storage']['db_bucket'], Key=exp_db_path, Body=pickle.dumps(mols_list))\n",
-    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)\n",
+    "build_database(config, input_db)\n",
     "polarity = input_data['polarity']\n",
     "isocalc_sigma = input_data['isocalc_sigma']\n",
-    "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)\n",
+    "calculate_centroids(config, input_db, polarity, isocalc_sigma)\n",
     "pipeline.segment_centroids()\n",
     "\n",
     "# Run Annotation:\n",
@@ -340,8 +340,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.molecular_db import clean_formula_chunks\n",
-    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
+    "from annotation_pipeline.utils import clean_from_cos"
    ]
   },
   {
@@ -350,7 +349,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.utils import clean_from_cos"
+    "# Clean formulas chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"formulas_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
    ]
   },
   {

--- a/experiment-2-interactive.ipynb
+++ b/experiment-2-interactive.ipynb
@@ -359,16 +359,6 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "# Clean centroids chunks\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
     "# Clean dataset chunks\n",
     "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], input_data[\"ds_chunks\"])"
    ]

--- a/experiment-2-interactive.ipynb
+++ b/experiment-2-interactive.ipynb
@@ -272,7 +272,7 @@
     "mols = pd.read_csv('metabolomics/db/mol_db5.csv')\n",
     "mols_list = sorted(set(mols.sf.values.tolist()))\n",
     "cos_client.put_object(Bucket=config['storage']['db_bucket'], Key=exp_db_path, Body=pickle.dumps(mols_list))\n",
-    "num_formulas, formula_chunk_keys = build_database(config, input_db)\n",
+    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)\n",
     "polarity = input_data['polarity']\n",
     "isocalc_sigma = input_data['isocalc_sigma']\n",
     "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)\n",
@@ -341,7 +341,7 @@
    "outputs": [],
    "source": [
     "from annotation_pipeline.molecular_db import clean_formula_chunks\n",
-    "clean_formula_chunks(config, input_db, formula_chunk_keys)"
+    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
    ]
   },
   {

--- a/experiment-3-large.ipynb
+++ b/experiment-3-large.ipynb
@@ -162,8 +162,8 @@
    },
    "outputs": [],
    "source": [
-    "#input_config = json.load(open('metabolomics/input_config_small.json'))\n",
-    "input_config = json.load(open('metabolomics/input_config_big.json'))\n",
+    "input_config = json.load(open('metabolomics/input_config_small.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_big.json'))\n",
     "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']"
@@ -293,16 +293,6 @@
    "source": [
     "# Clean formulas chunks\n",
     "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"formulas_chunks\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Clean centroids chunks\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
    ]
   },
   {

--- a/experiment-3-large.ipynb
+++ b/experiment-3-large.ipynb
@@ -224,10 +224,10 @@
     "dump_mol_db(config, config['storage']['db_bucket'], 'metabolomics/db/mol_db2.pickle', 19) #ChEBI-2018-01\n",
     "dump_mol_db(config, config['storage']['db_bucket'], 'metabolomics/db/mol_db3.pickle', 24) #LipidMaps-2017-12-12\n",
     "dump_mol_db(config, config['storage']['db_bucket'], 'metabolomics/db/mol_db4.pickle', 26) #SwissLipids-2018-02-02\n",
-    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)\n",
+    "build_database(config, input_db)\n",
     "polarity = input_data['polarity']\n",
     "isocalc_sigma = input_data['isocalc_sigma']\n",
-    "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)\n",
+    "calculate_centroids(config, input_db, polarity, isocalc_sigma)\n",
     "\n",
     "# Run Annotation Pipeline:\n",
     "pipeline = Pipeline(config, input_config)\n",
@@ -282,8 +282,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.molecular_db import clean_formula_chunks\n",
-    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
+    "from annotation_pipeline.utils import clean_from_cos"
    ]
   },
   {
@@ -292,7 +291,18 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.utils import clean_from_cos"
+    "# Clean formulas chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"formulas_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
    ]
   },
   {

--- a/experiment-3-large.ipynb
+++ b/experiment-3-large.ipynb
@@ -224,7 +224,7 @@
     "dump_mol_db(config, config['storage']['db_bucket'], 'metabolomics/db/mol_db2.pickle', 19) #ChEBI-2018-01\n",
     "dump_mol_db(config, config['storage']['db_bucket'], 'metabolomics/db/mol_db3.pickle', 24) #LipidMaps-2017-12-12\n",
     "dump_mol_db(config, config['storage']['db_bucket'], 'metabolomics/db/mol_db4.pickle', 26) #SwissLipids-2018-02-02\n",
-    "num_formulas, formula_chunk_keys = build_database(config, input_db)\n",
+    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)\n",
     "polarity = input_data['polarity']\n",
     "isocalc_sigma = input_data['isocalc_sigma']\n",
     "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)\n",
@@ -283,7 +283,7 @@
    "outputs": [],
    "source": [
     "from annotation_pipeline.molecular_db import clean_formula_chunks\n",
-    "clean_formula_chunks(config, input_db, formula_chunk_keys)"
+    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
    ]
   },
   {

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -9,8 +9,9 @@
     "isocalc_sigma": 0.00123792863514
   },
   "molecular_db": {
-    "formulas_chunks": "metabolomics/db/formulas",
-    "centroids_pandas": "metabolomics/db/centroids.pickle",
+    "formulas_chunks": "metabolomics/db/formulas_chunks",
+    "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "centroids_df": "metabolomics/db/centroids.pickle",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -11,7 +11,6 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "centroids_df": "metabolomics/db/centroids.pickle",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -9,8 +9,9 @@
     "isocalc_sigma": 0.00123792863514
   },
   "molecular_db": {
-    "formulas_chunks": "metabolomics/db/formulas",
-    "centroids_pandas": "metabolomics/db/centroids.pickle",
+    "formulas_chunks": "metabolomics/db/formulas_chunks",
+    "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "centroids_df": "metabolomics/db/centroids.pickle",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -11,7 +11,6 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "centroids_df": "metabolomics/db/centroids.pickle",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -11,7 +11,6 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "centroids_df": "metabolomics/db/centroids.pickle",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -9,8 +9,9 @@
     "isocalc_sigma": 0.000693240035678
   },
   "molecular_db": {
-    "formulas_chunks": "metabolomics/db/formulas",
-    "centroids_pandas": "metabolomics/db/centroids.pickle",
+    "formulas_chunks": "metabolomics/db/formulas_chunks",
+    "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "centroids_df": "metabolomics/db/centroids.pickle",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/pywren-annotation-pipeline.ipynb
+++ b/pywren-annotation-pipeline.ipynb
@@ -209,8 +209,8 @@
    "outputs": [],
    "source": [
     "import json\n",
-    "#input_config = json.load(open('metabolomics/input_config_small.json'))\n",
-    "input_config = json.load(open('metabolomics/input_config_big.json'))\n",
+    "input_config = json.load(open('metabolomics/input_config_small.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_big.json'))\n",
     "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']\n",
@@ -360,7 +360,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas = build_database(config, input_db)"
+    "num_formulas, num_formulas_chunks = build_database(config, input_db)"
    ]
   },
   {
@@ -375,16 +375,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "formula_to_id, id_to_formula = get_formula_id_dfs(config, input_db)"
+    "num_formulas, num_formulas_chunks"
    ]
   },
   {
@@ -401,7 +392,7 @@
    "source": [
     "polarity = input_data['polarity'] # Use '+' if missing from the config, but it's better to get the actual value as it affects the results\n",
     "isocalc_sigma = input_data['isocalc_sigma'] # Use 0.001238 if missing from the config, but it's better to get the actual value as it affects the results\n",
-    "centroids_shape, centroids_head = calculate_centroids(config, input_db, polarity, isocalc_sigma)"
+    "num_centroids, num_centroids_chunks = calculate_centroids(config, input_db, polarity, isocalc_sigma)"
    ]
   },
   {
@@ -416,32 +407,7 @@
    },
    "outputs": [],
    "source": [
-    "centroids_shape"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "centroids_head"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Centroids database in IBM COS\n",
-    "cos_client.list_objects_v2(Bucket=config['storage']['db_bucket'], Prefix=input_db['centroids_pandas']).get('Contents', [])"
+    "num_centroids, num_centroids_chunks"
    ]
   },
   {
@@ -607,16 +573,6 @@
    "source": [
     "# Clean formulas chunks\n",
     "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"formulas_chunks\"])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "# Clean centroids chunks\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
    ]
   },
   {

--- a/pywren-annotation-pipeline.ipynb
+++ b/pywren-annotation-pipeline.ipynb
@@ -325,7 +325,7 @@
    "outputs": [],
    "source": [
     "from annotation_pipeline.molecular_db import dump_mol_db, build_database, \\\n",
-    "    calculate_centroids, get_formula_id_dfs, clean_formula_chunks"
+    "    calculate_centroids, get_formula_id_dfs"
    ]
   },
   {
@@ -360,7 +360,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)"
+    "num_formulas = build_database(config, input_db)"
    ]
   },
   {
@@ -375,7 +375,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas, len(formula_chunk_keys), formula_chunk_keys[:3]"
+    "num_formulas"
    ]
   },
   {
@@ -384,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "formula_to_id, id_to_formula = get_formula_id_dfs(config, formula_keys)"
+    "formula_to_id, id_to_formula = get_formula_id_dfs(config, input_db)"
    ]
   },
   {
@@ -401,7 +401,7 @@
    "source": [
     "polarity = input_data['polarity'] # Use '+' if missing from the config, but it's better to get the actual value as it affects the results\n",
     "isocalc_sigma = input_data['isocalc_sigma'] # Use 0.001238 if missing from the config, but it's better to get the actual value as it affects the results\n",
-    "centroids_shape, centroids_head = calculate_centroids(config, input_db, formula_chunk_keys, polarity, isocalc_sigma)"
+    "centroids_shape, centroids_head = calculate_centroids(config, input_db, polarity, isocalc_sigma)"
    ]
   },
   {
@@ -432,21 +432,6 @@
    "outputs": [],
    "source": [
     "centroids_head"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
    ]
   },
   {
@@ -612,6 +597,26 @@
    "outputs": [],
    "source": [
     "from annotation_pipeline.utils import clean_from_cos"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean formulas chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"formulas_chunks\"])"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Clean centroids chunks\n",
+    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], input_data[\"centroids_chunks\"])"
    ]
   },
   {

--- a/pywren-annotation-pipeline.ipynb
+++ b/pywren-annotation-pipeline.ipynb
@@ -360,7 +360,7 @@
    },
    "outputs": [],
    "source": [
-    "num_formulas, formula_chunk_keys = build_database(config, input_db)"
+    "num_formulas, formula_keys, formula_chunk_keys = build_database(config, input_db)"
    ]
   },
   {
@@ -384,7 +384,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "formula_to_id, id_to_formula = get_formula_id_dfs(config, input_db)"
+    "formula_to_id, id_to_formula = get_formula_id_dfs(config, formula_keys)"
    ]
   },
   {
@@ -446,7 +446,7 @@
    },
    "outputs": [],
    "source": [
-    "clean_formula_chunks(config, input_db, formula_chunk_keys)"
+    "clean_formula_chunks(config, input_db, formula_chunk_keys + formula_keys)"
    ]
   },
   {

--- a/scripts/generate_centroids.py
+++ b/scripts/generate_centroids.py
@@ -5,7 +5,7 @@ import time
 from annotation_pipeline.__main__ import generate_centroids
 
 import logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate centroids', usage='')

--- a/scripts/generate_centroids.py
+++ b/scripts/generate_centroids.py
@@ -4,10 +4,13 @@ import time
 
 from annotation_pipeline.__main__ import generate_centroids
 
+import logging
+logging.basicConfig(level=logging.INFO)
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Generate centroids', usage='')
     parser.add_argument('--config', type=argparse.FileType('r'), default='config.json', help='config.json path')
-    parser.add_argument('--input-config', type=argparse.FileType('r'), default='input_config.json',
+    parser.add_argument('input', type=argparse.FileType('r'), default='input_config.json',
                         help='input_config.json path')
     args = parser.parse_args()
 

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -5,7 +5,7 @@ import time
 from annotation_pipeline.pipeline import Pipeline
 
 import logging
-logging.basicConfig(level=logging.INFO)
+logging.basicConfig(level=logging.DEBUG)
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run annotation pipeline', usage='')

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -4,17 +4,20 @@ import time
 
 from annotation_pipeline.pipeline import Pipeline
 
+import logging
+logging.basicConfig(level=logging.INFO)
+
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Run annotation pipeline', usage='')
     parser.add_argument('--config', type=argparse.FileType('r'), default='config.json', help='config.json path')
-    parser.add_argument('--input-config', type=argparse.FileType('r'), default='input_config.json',
+    parser.add_argument('input', type=argparse.FileType('r'), default='input_config.json',
                         help='input_config.json path')
     args = parser.parse_args()
 
     start = time.time()
 
     config = json.load(args.config)
-    input_config = json.load(args.input_config)
+    input_config = json.load(args.input)
 
     pipeline = Pipeline(config, input_config)
     pipeline()

--- a/scripts/upload_data.py
+++ b/scripts/upload_data.py
@@ -8,7 +8,7 @@ if __name__ == '__main__':
     parser = argparse.ArgumentParser(description='Upload input data to COS', usage='')
     parser.add_argument('paths', type=str, nargs='+', help='path to upload [`tmp` is ignored]')
     parser.add_argument('--config', type=argparse.FileType('r'), default='config.json', help='config.json path')
-    parser.add_argument('--input-config', type=argparse.FileType('r'), default='input_config.json',
+    parser.add_argument('input', type=argparse.FileType('r'), default='input_config.json',
                         help='input_config.json path')
     args = parser.parse_args()
 


### PR DESCRIPTION
This PR is intended to fix memory issues when we create 'big' and 'huge' databases.

**main changes**:
- separate `formula_to_id()` and `id_to_formula()` into an external method.
- edit `calculate_centroids()` to calculate centroids chunks instead of one large file.
- edit `segment_centroids()` to clip centroids chunks more efficiently.