### PR TITLE
Validate results_df

### DIFF
--- a/annotation_pipeline/check_results.py
+++ b/annotation_pipeline/check_results.py
@@ -1,0 +1,94 @@
+import numpy as np
+
+from annotation_pipeline.utils import logger
+
+
+def get_reference_results(metaspace_options, ds_id):
+    from metaspace.sm_annotation_utils import SMInstance
+    if metaspace_options.get('host'):
+        sm = SMInstance(host=metaspace_options['host'])
+    else:
+        sm = SMInstance()
+    if metaspace_options.get('password'):
+        sm.login(metaspace_options['email'], metaspace_options['password'])
+
+    ds = sm.dataset(id=ds_id)
+    reference_results = (ds.results('HMDB-v4')
+        .reset_index()
+        .rename({'moc': 'chaos', 'rhoSpatial': 'spatial', 'rhoSpectral': 'spectral'}, axis=1))
+    return reference_results[['formula', 'adduct', 'chaos', 'spatial', 'spectral', 'msm', 'fdr']]
+
+
+def check_results(results_df, ref_results):
+    def quantize_fdr(fdr):
+        if fdr <= 0.05: return 1
+        if fdr <= 0.1: return 2
+        if fdr <= 0.2: return 3
+        if fdr <= 0.5: return 4
+        return 5
+
+    def find_differing_rows(df, col_a, col_b, max_error=0.001):
+        return (df.assign(error=np.abs(df[col_a] - df[col_b]))
+            .sort_values('error', ascending=False)
+        [lambda d: d.error > max_error]
+        [[col_a, col_b, 'error']])
+
+    # clean up dataframes for better manual analysis & include only data that should be present in both dataframes
+    filtered_results = (results_df
+                        .rename({'mol': 'formula'}, axis=1)
+                        [lambda df: (df.database_path == 'metabolomics/db/mol_db1.pickle')
+                                    & (df.adduct != '')
+                                    & (df.modifier == '')]
+                        [['formula', 'adduct', 'chaos', 'spatial', 'spectral', 'msm', 'fdr']])
+
+    merged_results = (ref_results
+                      .merge(filtered_results, how='outer',
+                             left_on=['formula', 'adduct'], right_on=['formula', 'adduct'], suffixes=['_ref', ''])
+                      .sort_values(['formula', 'adduct']))
+
+    # Validate no missing results (Should be zero as it's not affected by numeric instability)
+    missing_results = merged_results[merged_results.fdr.isna() & merged_results.fdr_ref.notna()]
+
+    # Find missing/wrong results for metrics & MSM
+    common_results = merged_results[merged_results.fdr.notna() & merged_results.fdr_ref.notna()]
+    spatial_wrong = find_differing_rows(common_results, 'spatial', 'spatial_ref')
+    spectral_wrong = find_differing_rows(common_results, 'spectral', 'spectral_ref')
+    chaos_wrong = find_differing_rows(common_results, 'chaos', 'chaos_ref')
+    msm_wrong = find_differing_rows(common_results, 'msm', 'msm_ref')
+
+    # Validate FDR (Results often go up/down one level due to random factor)
+    fdr_level = merged_results.fdr.apply(quantize_fdr)
+    fdr_ref_level = merged_results.fdr_ref.apply(quantize_fdr)
+
+    fdr_exact = merged_results[fdr_level == fdr_ref_level]
+    fdr_close = merged_results[np.abs(fdr_level - fdr_ref_level) <= 1]
+    return {
+        'merged_results': merged_results,
+        'missing_results': missing_results,
+        'spatial_wrong': spatial_wrong,
+        'spectral_wrong': spectral_wrong,
+        'chaos_wrong': chaos_wrong,
+        'msm_wrong': msm_wrong,
+        'fdr_exact': fdr_exact,
+        'fdr_close': fdr_close,
+    }
+
+
+
+def log_bad_results(merged_results, missing_results, spatial_wrong, spectral_wrong, chaos_wrong, msm_wrong, fdr_exact, fdr_close):
+    if len(missing_results):
+        logger.error(f'{len(missing_results)} missing annotations: \n{missing_results.head()}')
+    if len(spatial_wrong) > 5:
+        # A small number of results are off by up to 1% due to an algorithm change since they were processed
+        # Annotations with fewer than 4 ion images now have slightly higher spectral score than before
+        logger.error(f'{len(spatial_wrong)} annotations with incorrect spatial metric:\n{spatial_wrong.head()}')
+    if len(spectral_wrong):
+        logger.error(f'{len(spectral_wrong)} annotations with incorrect spectral metric:\n{spectral_wrong.head()}')
+    if len(chaos_wrong):
+        logger.error(f'{len(chaos_wrong)} annotations with incorrect chaos metric:\n{chaos_wrong.head()}')
+    if len(msm_wrong):
+        logger.error(f'{len(msm_wrong)} annotations with incorrect MSM:\n{msm_wrong.head()}')
+    if len(fdr_exact) < len(merged_results) * 0.75:
+        logger.error(f'Not enough annotations with matching FDR: {len(fdr_exact)} out of {len(merged_results)}')
+    if len(fdr_close) < len(merged_results) * 0.9:
+        logger.error(f'Not enough annotations with FDR within tolerance: {len(fdr_close)} out of {len(merged_results)}')

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -47,7 +47,7 @@ def calculate_centroids(config, input_db, polarity='+', isocalc_sigma=0.001238, 
             'polarity': polarity,
             'n_charges': 1,
         },
-        'isocalc_sigma': isocalc_sigma
+        'isocalc_sigma': float(f"{isocalc_sigma:f}") # Rounding to match production implementation
     })
 
     pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -131,20 +131,6 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "#Install psutil if needed\n",
-    "try:\n",
-    "    import psutil\n",
-    "except ModuleNotFoundError:    \n",
-    "    !{sys.executable} -m pip install -U psutil\n",
-    "    import psutil"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {
     "pycharm": {
      "metadata": false,
@@ -155,6 +141,18 @@
    "source": [
     "import logging\n",
     "logging.basicConfig(level=logging.INFO)"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set a socket timeout so that CF requests fail instead of hanging if they don't get a response\n",
+    "import socket\n",
+    "print('Previous timeout:', socket.getdefaulttimeout())\n",
+    "socket.setdefaulttimeout(60)"
    ]
   },
   {
@@ -194,8 +192,8 @@
    },
    "outputs": [],
    "source": [
-    "#input_config = json.load(open('metabolomics/input_config_small.json'))\n",
-    "input_config = json.load(open('metabolomics/input_config_big.json'))\n",
+    "input_config = json.load(open('metabolomics/input_config_small.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_big.json'))\n",
     "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']\n",
@@ -299,7 +297,7 @@
    "outputs": [],
    "source": [
     "import os\n",
-    "import psutil # \"pip install psutil\" if needed\n",
+    "import psutil\n",
     "import pandas as pd\n",
     "from datetime import datetime\n",
     "memory_usage_mb = psutil.Process(os.getpid()).memory_info().rss / 2**20\n",
@@ -446,10 +444,7 @@
    "outputs": [],
    "source": [
     "sm = SMInstance()\n",
-    "# TODO: (EMBL) Reprocess these datasets with the other DBs, because currently they only have HMDB-v4\n",
-    "ds = sm.dataset(id='2016-09-22_11h16m11s') # For input_config_small.json\n",
-    "#ds = sm.dataset(id='2016-09-21_16h06m52s') # For input_config_big.json\n",
-    "#ds = sm.dataset(id='2016-09-21_16h06m49s') # For input_config_huge.json"
+    "ds = sm.dataset(id=input_data['metaspace_id'])"
    ]
   },
   {
@@ -474,80 +469,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "results_df[lambda df: (df.mol == 'C42H84NO8P') & (df.adduct == '+H')]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "reference_results = ds.results()\n",
-    "reference_results = reference_results.rename({'moc':'chaos', 'rhoSpatial': 'spatial', 'rhoSpectral': 'spectral'}, axis=1)\n",
-    "reference_results = reference_results[['chaos', 'spatial', 'spectral', 'msm', 'fdr']]\n",
-    "reference_results = reference_results.reset_index()\n",
-    "\n",
-    "filtered_results = results_df\n",
-    "filtered_results = filtered_results[filtered_results.database_path == 'metabolomics/db/mol_db1.pickle']\n",
-    "#filtered_results = filtered_results[filtered_results.fdr <= 0.5]\n",
-    "filtered_results = filtered_results[filtered_results.adduct != '']\n",
-    "filtered_results = filtered_results[filtered_results.modifier == '']\n",
-    "filtered_results = filtered_results.rename({'mol': 'formula'}, axis=1)\n",
-    "filtered_results = filtered_results[['chaos', 'spatial', 'spectral', 'msm', 'fdr', 'formula', 'adduct', 'modifier']]\n",
-    "\n",
-    "merged_results = reference_results.merge(filtered_results, how='outer', left_on=['formula','adduct'], right_on=['formula','adduct'], suffixes=['_ref',''])\n",
-    "merged_results = merged_results.sort_values(['formula','adduct'])"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "common_results[['spatial', 'spatial_ref']]"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "common_results = merged_results[merged_results.fdr.notna() & merged_results.fdr_ref.notna()]\n",
-    "spatial_wrong = common_results[np.abs((common_results.spatial - common_results.spatial_ref)) >= 0.01]\n",
-    "assert len(spatial_wrong) < 5, spatial_wrong # Higher tolerance because older DSs seem to have used a different algorithm\n",
-    "spectral_wrong = common_results[np.abs((common_results.spectral - common_results.spectral_ref)) >= 0.001]\n",
-    "assert len(spectral_wrong) <= 1, spectral_wrong\n",
-    "chaos_wrong = common_results[np.abs((common_results.chaos - common_results.chaos_ref)) >= 0.01]\n",
-    "assert len(chaos_wrong) <= 1, chaos_wrong\n",
-    "msm_wrong = common_results[np.abs((common_results.msm - common_results.msm_ref)) >= 0.001]\n",
-    "assert len(msm_wrong) <= 10, msm_wrong"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {},
-   "outputs": [],
-   "source": [
-    "\n",
-    "def quantize_fdr(fdr):\n",
-    "    if fdr <= 0.05: return 1\n",
-    "    if fdr <= 0.1: return 2\n",
-    "    if fdr <= 0.2: return 3\n",
-    "    if fdr <= 0.5: return 4\n",
-    "    return 5\n",
-    "    \n",
-    "fdr_level = merged_results.fdr.apply(quantize_fdr)\n",
-    "fdr_ref_level = merged_results.fdr_ref.apply(quantize_fdr)\n",
-    "\n",
-    "fdr_exact = merged_results[fdr_level == fdr_ref_level]\n",
-    "fdr_near = merged_results[np.abs(fdr_level - fdr_ref_level) <= 1]\n",
-    "print(len(fdr_exact), len(fdr_near), len(merged_results))\n",
-    "assert len(fdr_exact) >= len(merged_results) * 0.5\n",
-    "assert len(fdr_near) >= len(merged_results) * 0.8"
+    "checked_results = pipeline.check_results()"
    ]
   },
   {
@@ -629,9 +551,9 @@
  ],
  "metadata": {
   "kernelspec": {
-   "display_name": "Python 3",
+   "display_name": "Python [conda env:sm]",
    "language": "python",
-   "name": "python3"
+   "name": "conda-env-sm-py"
   },
   "language_info": {
    "codemirror_mode": {
@@ -643,7 +565,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.6.0"
+   "version": "3.6.8"
   },
   "stem_cell": {
    "cell_type": "raw",

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -192,8 +192,8 @@
    },
    "outputs": [],
    "source": [
-    "input_config = json.load(open('metabolomics/input_config_small.json'))\n",
-    "#input_config = json.load(open('metabolomics/input_config_big.json'))\n",
+    "#input_config = json.load(open('metabolomics/input_config_small.json'))\n",
+    "input_config = json.load(open('metabolomics/input_config_big.json'))\n",
     "#input_config = json.load(open('metabolomics/input_config_huge.json'))\n",
     "input_data = input_config['dataset']\n",
     "input_db = input_config['molecular_db']\n",
@@ -460,7 +460,7 @@
    "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "# Check results are correct (WIP)"
+    "# Check results are correct"
    ]
   },
   {

--- a/input_config.json.template
+++ b/input_config.json.template
@@ -6,7 +6,8 @@
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
-    "isocalc_sigma": 0.00123792863514
+    "isocalc_sigma": 0.00123792863514,
+    "metaspace_id": "****"
   },
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas",

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -5,8 +5,9 @@
     "ds_segments": "metabolomics/tmp/ds_segments",
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
-    "polarity": "-",
-    "isocalc_sigma": 0.00123792863514
+    "polarity": "+",
+    "isocalc_sigma": 0.001238,
+    "metaspace_id": "2016-09-21_16h06m53s"
   },
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
@@ -18,7 +19,7 @@
       "metabolomics/db/mol_db3.pickle",
       "metabolomics/db/mol_db4.pickle"
     ],
-    "adducts": ["","-H","+Cl"],
+    "adducts": ["", "+H", "+Na", "+K"],
     "modifiers": ["", "-H2O", "-CO2", "-NH3"]
   },
   "output": {

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -6,7 +6,8 @@
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
-    "isocalc_sigma": 0.00123792863514
+    "isocalc_sigma": 0.00123792863514,
+    "metaspace_id": "2016-09-21_16h06m49s"
   },
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -17,8 +17,8 @@
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle"
     ],
-    "adducts": ["","+H"],
-    "modifiers": ["", "-H2O"]
+    "adducts": ["","+H","+Na","+K"],
+    "modifiers": [""]
   },
   "output": {
     "formula_images": "metabolomics/tmp/formula_images"

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -17,8 +17,8 @@
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle"
     ],
-    "adducts": ["","+H","+Na","+K"],
-    "modifiers": [""]
+    "adducts": ["","+H"],
+    "modifiers": ["", "-H2O"]
   },
   "output": {
     "formula_images": "metabolomics/tmp/formula_images"

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -6,7 +6,8 @@
     "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
-    "isocalc_sigma": 0.000693240035678
+    "isocalc_sigma": 0.000693240035678,
+    "metaspace_id": "2016-09-22_11h16m11s"
   },
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",

--- a/pywren-annotation-pipeline.ipynb
+++ b/pywren-annotation-pipeline.ipynb
@@ -19,7 +19,8 @@
     "2. [Upload Dataset into IBM COS](#dataset)\n",
     "3. [Generate Isotopic Peaks from Molecular Databases](#database)\n",
     "4. [Run Annotation Pipeline](#annotation)\n",
-    "5. [Clean Temp Data in IBM COS](#clean)"
+    "5. [Validate results](#validate)\n",
+    "6. [Clean Temp Data in IBM COS](#clean)"
    ]
   },
   {
@@ -182,6 +183,18 @@
     "    import pywren_ibm_cloud as pywren\n",
     "\n",
     "pywren.__version__"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "# Set a socket timeout so that CF requests fail instead of hanging if they don't get a response\n",
+    "import socket\n",
+    "print('Previous timeout:', socket.getdefaulttimeout())\n",
+    "socket.setdefaulttimeout(60)"
    ]
   },
   {
@@ -531,6 +544,13 @@
    ]
   },
   {
+   "cell_type": "markdown",
+   "metadata": {},
+   "source": [
+    "# <a name=\"validate\"></a> 5. Validate results"
+   ]
+  },
+  {
    "cell_type": "code",
    "execution_count": null,
    "metadata": {},
@@ -541,6 +561,15 @@
    ]
   },
   {
+   "cell_type": "code",
+   "execution_count": null,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "checked_results = pipeline.check_results()"
+   ]
+  },
+  {
    "cell_type": "markdown",
    "metadata": {
     "pycharm": {
@@ -548,7 +577,7 @@
     }
    },
    "source": [
-    "# <a name=\"clean\"></a> 5. Clean Temp Data in IBM COS"
+    "# <a name=\"clean\"></a> 6. Clean Temp Data in IBM COS"
    ]
   },
   {

--- a/runtime/Dockerfile
+++ b/runtime/Dockerfile
@@ -2,10 +2,10 @@
 
 FROM ibmfunctions/action-python-v3.6:master
 
-RUN pip install cpyImagingMSpec==0.3.2
+RUN pip install cpyImagingMSpec==0.2.4
 RUN pip install pandas==0.24.1
 RUN pip install pyImagingMSpec==0.1.4
 RUN pip install pyMSpec==0.1.2
-RUN pip install cpyMSpec==0.4.2
+RUN pip install cpyMSpec==0.3.5
 RUN pip install pyimzML==1.2.5
 RUN pip install msgpack-numpy

--- a/setup.py
+++ b/setup.py
@@ -21,5 +21,7 @@ setup(name='pywren-annotation-pipeline',
           "cpyMSpec==0.4.2",
           "pyimzML==1.2.5",
           "requests",
-          "msgpack-numpy"
+          "msgpack-numpy",
+          "metaspace2020", # Only needed for experiment notebooks
+          "psutil", # Only needed for experiment notebooks
       ])


### PR DESCRIPTION
This PR adds code to check that the `results_df` has the same or very similar data to our production server in Experiment 1. It's only intended for use with the "big" dataset per that experiment. I haven't looked deeply into the discrepancies it finds with the "small" and "large" datasets, but it's possible that they're all due to code changes in the engine since the dataset was processed.

@gilv Please rebuild the runtime after this has been merged. I had to downgrade some of the dependencies to older versions so that they produced the same values as our production server.

This PR also includes 3 unrelated changes:
* Makes dataset upload partially multi-threaded so that slow network has a smaller impact. On my computer this speeds it up from 66s to 32s.
* Adds `socket.setdefaulttimeout(60)` so that if the SSL freeze issue that we discussed in Slack happens, then it will throw an exception instead of never returning
* Removes inline `pip install metaspace2020` and `pip install psutil` calls from the notebooks, and adds them to `setup.py` instead