### PR TITLE
add support for build massive centroids databases

### DIFF
--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -76,13 +76,13 @@ def build_database(config, input_db):
         if None in formulas:
             formulas.remove(None)
 
-        chunk = pd.DataFrame(sorted(formulas), columns=['formula'])
+        chunk = pd.DataFrame(sorted(set(formulas)), columns=['formula'])
         chunk.index.name = 'formula_i'
         database_name = key.split('/')[-1].split('.')[0]
         chunk_key = f'{formulas_chunks_prefix}/{database_name}/{adduct}.msgpack'
         ibm_cos.put_object(Bucket=bucket, Key=chunk_key, Body=chunk.to_msgpack())
 
-        return len(formulas)
+        return len(chunk)
 
     adducts = [*input_db['adducts'], *DECOY_ADDUCTS]
     modifiers = input_db['modifiers']

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -35,7 +35,7 @@ def calculate_centroids(config, input_db, polarity='+', isocalc_sigma=0.001238):
         peaks_df = pd.DataFrame(peaks, columns=['formula_i', 'peak_i', 'mz', 'int'])
         peaks_df.set_index('formula_i', inplace=True)
 
-        chunk_i = '/'.join(key.split('/')[-2:]).split('.')[0]
+        chunk_i = key.split('/')[-1].split('.')[0]
         centroids_chunk_key = f'{centroids_chunks_prefix}/{chunk_i}.msgpack'
         ibm_cos.put_object(Bucket=bucket, Key=centroids_chunk_key, Body=peaks_df.to_msgpack())
 

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -5,6 +5,7 @@ from concurrent.futures import ThreadPoolExecutor
 import pywren_ibm_cloud as pywren
 import pandas as pd
 import pickle
+import hashlib
 
 from annotation_pipeline.formula_parser import safe_generate_ion_formula
 from annotation_pipeline.utils import get_ibm_cos_client, append_pywren_stats, clean_from_cos
@@ -71,7 +72,11 @@ def build_database(config, input_db):
     databases = input_db['databases']
 
     max_n_segments = 256
-    hash_formula_to_segment = lambda formula: hash(formula) % max_n_segments
+
+    def hash_formula_to_segment(formula):
+        m = hashlib.md5()
+        m.update(formula.encode('utf-8'))
+        return int(m.hexdigest(), 16) % max_n_segments
 
     def generate_formulas(key, data_stream, ibm_cos):
         database_name = key.split('/')[-1].split('.')[0]


### PR DESCRIPTION
**main changes**:
`build_database()` method now firstly creates formulas chunks with duplications for each database and adduct. then we segment each chunk into 256 segments by a hash function so every group of same formulas will be sorted into the same segment (as discussed in slack). after that, we deduplicate each segment.

notice that currently we use maximum number of 100k temp files in estimate for this feature (for the "ultra-huge" database), we will work on PyWren side feature that will allow to use much fewer temp files