### PR TITLE
Remove unnecessary dependency on datasets' config.json files

### DIFF
--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -45,9 +45,6 @@ class Pipeline(object):
         self.sp_n = len(self.coordinates)
         logger.info(f'Parsed imzml: {self.sp_n} spectra found')
 
-        ds_config = json.load(open(Path(self.input_data['path']) / 'config.json'))
-        self.isotope_gen_config = ds_config['isotope_generation']
-
     def split_ds(self):
         clean_from_cos(self.config, self.config["storage"]["ds_bucket"], self.input_data["ds_chunks"])
         self.specra_chunks_keys = chunk_spectra(self.config, self.input_data, self.sp_n, self.imzml_parser, self.coordinates)


### PR DESCRIPTION
`Pipeline.isotope_gen_config` is populated but never actually used. Removing this means that the dataset's `config.json` isn't needed (unrelated to `input_config.json` or the pywren `config.json`).