### PR TITLE
Segment centroids in chunks

### DIFF
--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -91,7 +91,7 @@ def create_process_segment(ds_bucket, ds_segments_prefix, output_bucket, formula
     ppm = image_gen_config['ppm']
 
     def process_centr_segment(bucket, key, data_stream, ibm_cos):
-        segm_i = int(key.split("/")[-1].split(".msgpack")[0])
+        segm_i = f'{key.split("/")[-2]}/{key.split("/")[-1].split(".msgpack")[0]}'
         print(f'Reading centroids segment {segm_i} from {key}')
         centr_df = pd.read_msgpack(data_stream._raw_stream)
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -7,7 +7,8 @@ import pandas as pd
 from annotation_pipeline.check_results import get_reference_results, check_results, log_bad_results
 from annotation_pipeline.fdr import build_fdr_rankings, calculate_fdrs
 from annotation_pipeline.image import create_process_segment
-from annotation_pipeline.segment import define_ds_segments, chunk_spectra, segment_spectra, segment_centroids, clip_centroids_df_per_chunk
+from annotation_pipeline.segment import define_ds_segments, chunk_spectra, segment_spectra, segment_centroids,\
+    clip_centroids_df_per_chunk, define_centr_segments
 from annotation_pipeline.utils import ds_imzml_path, clean_from_cos, get_ibm_cos_client, append_pywren_stats
 from annotation_pipeline.utils import logger
 
@@ -56,17 +57,21 @@ class Pipeline(object):
         logger.info(f'Segmented dataset chunks into {self.ds_segm_n} segments')
 
     def segment_centroids(self):
-        clean_from_cos(self.config, self.config["storage"]["db_bucket"], self.input_db["clipped_centroids_chunks"])
         mz_min, mz_max = self.ds_segments_bounds[0, 0], self.ds_segments_bounds[-1, 1]
+
+        clean_from_cos(self.config, self.config["storage"]["db_bucket"], self.input_db["clipped_centroids_chunks"])
         self.centr_n = clip_centroids_df_per_chunk(self.config, self.config["storage"]["db_bucket"],
                                                    self.input_db["centroids_chunks"],
                                                    self.input_db["clipped_centroids_chunks"], mz_min, mz_max)
+
         clean_from_cos(self.config, self.config["storage"]["db_bucket"], self.input_db["centroids_segments"])
-        self.centr_segm_n = segment_centroids(self.config, self.config["storage"]["db_bucket"],
-                                              self.input_db["clipped_centroids_chunks"],
-                                              self.input_db["centroids_segments"], self.centr_n, self.ds_segm_n,
-                                              self.ds_segm_size_mb)
-        logger.info(f'Segmented database chunks into {self.centr_segm_n} segments')
+        self.centr_segm_lower_bounds = define_centr_segments(self.config, self.config["storage"]["db_bucket"],
+                                                             self.input_db["clipped_centroids_chunks"], self.centr_n,
+                                                             self.ds_segm_n, self.ds_segm_size_mb)
+        self.centr_segm_n = len(self.centr_segm_lower_bounds)
+        segment_centroids(self.config, self.config["storage"]["db_bucket"], self.input_db["clipped_centroids_chunks"],
+                          self.input_db["centroids_segments"], self.centr_segm_lower_bounds)
+        logger.info(f'Segmented centroids chunks into {self.centr_segm_n} segments')
 
     def annotate(self):
         logger.info('Annotating...')

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -34,7 +34,7 @@ class Pipeline(object):
 
     def __call__(self, *args, **kwargs):
         self.load_ds()
-        #self.split_ds()
+        self.split_ds()
         self.segment_ds()
         self.segment_centroids()
         self.annotate()
@@ -65,14 +65,14 @@ class Pipeline(object):
                                                    self.input_db["centroids_chunks"],
                                                    self.input_db["clipped_centroids_chunks"], mz_min, mz_max)
 
-        self.db_segments_bounds = define_db_segments(self.config, self.config["storage"]["db_bucket"],
+        self.db_segm_lower_bounds = define_db_segments(self.config, self.config["storage"]["db_bucket"],
                                                      self.input_db["clipped_centroids_chunks"], self.centr_n,
                                                      self.ds_segm_n, self.ds_segm_size_mb)
-        self.centr_segm_n = len(self.db_segments_bounds)
+        self.centr_segm_n = len(self.db_segm_lower_bounds)
 
         clean_from_cos(self.config, self.config["storage"]["db_bucket"], self.input_db["centroids_segments"])
         segment_centroids(self.config, self.config["storage"]["db_bucket"], self.input_db["clipped_centroids_chunks"],
-                          self.input_db["centroids_segments"], self.db_segments_bounds)
+                          self.input_db["centroids_segments"], self.db_segm_lower_bounds)
 
     def annotate(self):
         logger.info('Annotating...')

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -60,6 +60,8 @@ class Pipeline(object):
     def segment_centroids(self):
         clean_from_cos(self.config, self.config["storage"]["db_bucket"], self.input_db["centroids_segments"])
         mz_min, mz_max = self.ds_segments_bounds[0, 0], self.ds_segments_bounds[-1, 1]
+        self.centr_n
+        self.db_segments_bounds
         self.centr_n, self.centr_segm_n = segment_centroids(self.config, self.config["storage"]["db_bucket"],
                                                             self.input_db["centroids_chunks"],
                                                             self.input_db["centroids_segments"], mz_min, mz_max,

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -78,7 +78,7 @@ def spectra_sample_gen(imzml_parser, sample_ratio=0.05):
 
 
 def define_ds_segments(imzml_parser, ds_segm_size_mb=5, sample_ratio=0.05):
-    logger.info('Defining dataset segment bounds')
+    logger.info('Defining dataset segments bounds')
     spectra_sample = list(spectra_sample_gen(imzml_parser, sample_ratio=sample_ratio))
 
     spectra_mzs = np.array([mz for sp_id, mzs, ints in spectra_sample for mz in mzs])
@@ -94,7 +94,7 @@ def define_ds_segments(imzml_parser, ds_segm_size_mb=5, sample_ratio=0.05):
     segm_lower_bounds = [np.quantile(spectra_mzs, q) for q in segm_bounds_q]
     ds_segments = np.array(list(zip(segm_lower_bounds[:-1], segm_lower_bounds[1:])))
 
-    logger.info(f'Generated {len(ds_segments)} dataset segments: {ds_segments[0]}...{ds_segments[-1]}')
+    logger.info(f'Generated {len(ds_segments)} bounds: {ds_segments[0]}...{ds_segments[-1]} for {len(ds_segments)} dataset segments')
     return ds_segments
 
 
@@ -175,44 +175,46 @@ def clip_centroids_df_per_chunk(config, bucket, centr_chunks_prefix, clip_centr_
     return centr_n
 
 
-def define_db_segments(config, bucket, clip_centr_chunk_prefix, centr_n, ds_segm_n, ds_segm_size_mb):
-    logger.info('Defining database segment bounds')
-
-    ds_size_mb = ds_segm_n * ds_segm_size_mb
-    data_per_centr_segm_mb = 50
-    peaks_per_centr_segm = 1e5
-    centr_segm_n = int(max(ds_size_mb // data_per_centr_segm_mb, centr_n // peaks_per_centr_segm, 32))
-    centr_segm_n = min(centr_segm_n, 1000)
+def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix, centr_n, ds_segm_n, ds_segm_size_mb):
+    logger.info('Defining database segments bounds')
 
     def get_first_peak_mz(bucket, key, data_stream):
         centr_df = pd.read_msgpack(data_stream._raw_stream)
         first_peak_df = centr_df[centr_df.peak_i == 0]
         return first_peak_df.mz
 
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=4096)
+    pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
     futures = pw.map(get_first_peak_mz, f'{bucket}/{clip_centr_chunk_prefix}/')
-    mz = pd.concat(pw.get_result(futures))
+    first_peak_df_mz = pd.concat(pw.get_result(futures))
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
 
-    segm_bounds_q = [i * 1 / centr_segm_n for i in range(0, centr_segm_n)]
-    db_segm_lower_bounds = list(np.quantile(mz, q) for q in segm_bounds_q)
+    temp_centr_segm_n = 32
+    ds_size_mb = ds_segm_n * ds_segm_size_mb
+    data_per_centr_segm_mb = 50
+    peaks_per_centr_segm = 1e4
+    centr_segm_n = int(max(ds_size_mb // data_per_centr_segm_mb, centr_n // peaks_per_centr_segm, 32))
+    centr_segm_n = (centr_segm_n // temp_centr_segm_n) * temp_centr_segm_n  # temp_centr_segm_n has to divide centr_segm_n
 
-    logger.info(f'Generated {len(db_segm_lower_bounds)} database segments: {db_segm_lower_bounds[0]}...{db_segm_lower_bounds[-1]}')
-    return db_segm_lower_bounds
+    def generate_centr_segm_bounds(centr_segm_n, first_peak_df_mz):
+        segm_bounds_q = [i * 1 / centr_segm_n for i in range(0, centr_segm_n)]
+        db_segm_lower_bounds = list(np.quantile(first_peak_df_mz, q) for q in segm_bounds_q)
+        return db_segm_lower_bounds
 
+    db_segm_lower_bounds = generate_centr_segm_bounds(temp_centr_segm_n, first_peak_df_mz)
+    logger.info(f'Generated {len(db_segm_lower_bounds)} bounds: {db_segm_lower_bounds[0]}...{db_segm_lower_bounds[-1]} for {centr_segm_n} database segments')
 
-def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix, db_segm_lower_bounds):
-
-    def segment_centr_df_chunk(bucket, key, data_stream, ibm_cos):
-        ch_i = int(key.split("/")[-1].split(".msgpack")[0])
-        print(f'Segmenting clipped centroids chunk {ch_i}')
-        centr_df = pd.read_msgpack(data_stream._raw_stream)
-
+    def segment_centr_df(centr_df, db_segm_lower_bounds):
         first_peak_df = centr_df[centr_df.peak_i == 0].copy()
         segment_mapping = np.searchsorted(db_segm_lower_bounds, first_peak_df.mz.values, side='right') - 1
         first_peak_df['segm_i'] = segment_mapping
-        centr_segm_df = pd.merge(centr_df, first_peak_df[['formula_i', 'segm_i']],
-                                 on='formula_i').sort_values('mz')
+        centr_segm_df = pd.merge(centr_df, first_peak_df[['formula_i', 'segm_i']], on='formula_i').sort_values('mz')
+        return centr_segm_df
+
+    def upload_centr_df_segments_per_chunk(bucket, key, data_stream, ibm_cos):
+        ch_i = int(key.split("/")[-1].split(".msgpack")[0])
+        print(f'Segmenting clipped centroids chunk {ch_i}')
+        centr_df = pd.read_msgpack(data_stream._raw_stream)
+        centr_segm_df = segment_centr_df(centr_df, db_segm_lower_bounds)
 
         def _upload(args):
             segm_i, df = args
@@ -223,12 +225,12 @@ def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix
         with ThreadPoolExecutor(max_workers=128) as pool:
             pool.map(_upload, [(segm_i, df) for segm_i, df in centr_segm_df.groupby('segm_i')])
 
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=4096)
-    futures = pw.map(segment_centr_df_chunk, f'{bucket}/{clip_centr_chunk_prefix}')
+    pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
+    futures = pw.map(upload_centr_df_segments_per_chunk, f'{bucket}/{clip_centr_chunk_prefix}')
     pw.get_result(futures)
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
 
-    def merge_centr_df_segments(segm_i, ibm_cos):
+    def merge_centr_df_segments_per_chunk(segm_i, ibm_cos):
         print(f'Merging segment {segm_i} clipped centroids chunks')
 
         objs = ibm_cos.list_objects_v2(Bucket=bucket, Prefix=f'{centr_segm_prefix}/chunk/{segm_i}/')
@@ -242,14 +244,27 @@ def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix
 
             with ThreadPoolExecutor(max_workers=128) as pool:
                 segm = pd.concat(list(pool.map(_merge, keys)))
+                del segm['segm_i']
 
             clean_from_cos(config, bucket, f'{centr_segm_prefix}/chunk/{segm_i}/', ibm_cos)
-            ibm_cos.put_object(Bucket=bucket,
-                               Key=f'{centr_segm_prefix}/{segm_i}.msgpack',
-                               Body=segm.to_msgpack())
+            first_peak_df_mz = segm[segm.peak_i == 0].mz.values
+            sub_centr_segm_n = centr_segm_n // temp_centr_segm_n
+            sub_segm_lower_bounds = generate_centr_segm_bounds(sub_centr_segm_n, first_peak_df_mz)
+            centr_segm_df = segment_centr_df(segm, sub_segm_lower_bounds)
 
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=4096)
-    futures = pw.map(merge_centr_df_segments, range(len(db_segm_lower_bounds)))
+            def _upload(args):
+                sub_segm_i, df = args
+                ibm_cos.put_object(Bucket=bucket,
+                                   Key=f'{centr_segm_prefix}/{segm_i}/{sub_segm_i}.msgpack',
+                                   Body=df.to_msgpack())
+
+            with ThreadPoolExecutor(max_workers=128) as pool:
+                pool.map(_upload, [(segm_i, df) for segm_i, df in centr_segm_df.groupby('segm_i')])
+
+    pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
+    futures = pw.map(merge_centr_df_segments_per_chunk, range(len(db_segm_lower_bounds)))
     pw.get_result(futures)
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
+
+    return centr_segm_n
 

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -230,7 +230,7 @@ def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix
     pw.get_result(futures)
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
 
-    def merge_centr_df_segments_per_chunk(segm_i, ibm_cos):
+    def merge_centr_df_segments(segm_i, ibm_cos):
         print(f'Merging segment {segm_i} clipped centroids chunks')
 
         objs = ibm_cos.list_objects_v2(Bucket=bucket, Prefix=f'{centr_segm_prefix}/chunk/{segm_i}/')
@@ -262,7 +262,7 @@ def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix
                 pool.map(_upload, [(segm_i, df) for segm_i, df in centr_segm_df.groupby('segm_i')])
 
     pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
-    futures = pw.map(merge_centr_df_segments_per_chunk, range(len(db_segm_lower_bounds)))
+    futures = pw.map(merge_centr_df_segments, range(len(db_segm_lower_bounds)))
     pw.get_result(futures)
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
 

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -139,7 +139,7 @@ def segment_spectra(config, bucket, ds_chunks_prefix, ds_segments_prefix, ds_seg
                 segm_spectra_chunk = msgpack.loads(ibm_cos.get_object(Bucket=bucket, Key=key)['Body'].read())
                 segm.append(segm_spectra_chunk)
 
-            clean_from_cos(config, bucket, f'{ds_segments_prefix}/chunk/{segm_i}/')
+            clean_from_cos(config, bucket, f'{ds_segments_prefix}/chunk/{segm_i}/', ibm_cos)
             ibm_cos.put_object(Bucket=bucket,
                                Key=f'{ds_segments_prefix}/{segm_i}.msgpack',
                                Body=msgpack.dumps(segm))
@@ -241,7 +241,7 @@ def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix
             with ThreadPoolExecutor(max_workers=128) as pool:
                 segm = pd.concat(list(pool.map(_merge, keys)))
 
-            clean_from_cos(config, bucket, f'{centr_segm_prefix}/chunk/{segm_i}/')
+            clean_from_cos(config, bucket, f'{centr_segm_prefix}/chunk/{segm_i}/', ibm_cos)
             ibm_cos.put_object(Bucket=bucket,
                                Key=f'{centr_segm_prefix}/{segm_i}.msgpack',
                                Body=segm.to_msgpack())

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -139,7 +139,7 @@ def segment_spectra(config, bucket, ds_chunks_prefix, ds_segments_prefix, ds_seg
                 segm_spectra_chunk = msgpack.loads(ibm_cos.get_object(Bucket=bucket, Key=key)['Body'].read())
                 segm.append(segm_spectra_chunk)
 
-            clean_from_cos(config, bucket, f'{ds_segments_prefix}/chunk/{segm_i}/', ibm_cos)
+            clean_from_cos(config, bucket, f'{ds_segments_prefix}/chunk/{segm_i}/')
             ibm_cos.put_object(Bucket=bucket,
                                Key=f'{ds_segments_prefix}/{segm_i}.msgpack',
                                Body=msgpack.dumps(segm))
@@ -150,26 +150,32 @@ def segment_spectra(config, bucket, ds_chunks_prefix, ds_segments_prefix, ds_seg
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
 
 
-def segment_centroids(config, bucket, centr_chunks_prefix, centr_segm_prefix, mz_min, mz_max, ds_segm_n, ds_segm_size_mb):
-    db_prefix_bucket_key = f'{bucket}/{centr_chunks_prefix}/'
+def clip_centroids_df_per_chunk(config, bucket, centr_chunks_prefix, clip_centr_chunk_prefix, mz_min, mz_max):
 
-    def clip_centroids_df_per_chunk(bucket, key, data_stream):
+    def _clip(bucket, key, data_stream, chunk_i, ibm_cos):
         centroids_df_chunk = pd.read_msgpack(data_stream._raw_stream).sort_values('mz')
         centroids_df_chunk = centroids_df_chunk[centroids_df_chunk.mz > 0]
 
         ds_mz_range_unique_formulas = centroids_df_chunk[(mz_min < centroids_df_chunk.mz) &
-                                                   (centroids_df_chunk.mz < mz_max)].index.unique()
+                                                         (centroids_df_chunk.mz < mz_max)].index.unique()
         centr_df_chunk = centroids_df_chunk[centroids_df_chunk.index.isin(ds_mz_range_unique_formulas)].reset_index()
-        return centr_df_chunk
+        ibm_cos.put_object(Bucket=bucket,
+                           Key=f'{clip_centr_chunk_prefix}/{chunk_i}.msgpack',
+                           Body=centr_df_chunk.to_msgpack())
 
-    def get_clipped_centroids_df_shape(bucket, key, data_stream):
-        centr_df_chunk = clip_centroids_df_per_chunk(bucket, key, data_stream)
         return centr_df_chunk.shape[0]
 
-    pw = pywren.ibm_cf_executor(config=config, runtime_memory=512)
-    futures = pw.map(get_clipped_centroids_df_shape, db_prefix_bucket_key)
+    pw = pywren.ibm_cf_executor(config=config, runtime_memory=2048)
+    futures = pw.map(_clip, f'{bucket}/{centr_chunks_prefix}/')
     centr_n = sum(pw.get_result(futures))
     append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
+
+    logger.info(f'Prepared {centr_n} centroids')
+    return centr_n
+
+
+def define_db_segments(config, bucket, clip_centr_chunk_prefix, centr_n, ds_segm_n, ds_segm_size_mb):
+    logger.info('Defining database segment bounds')
 
     ds_size_mb = ds_segm_n * ds_segm_size_mb
     data_per_centr_segm_mb = 50
@@ -177,35 +183,74 @@ def segment_centroids(config, bucket, centr_chunks_prefix, centr_segm_prefix, mz
     centr_segm_n = int(max(ds_size_mb // data_per_centr_segm_mb, centr_n // peaks_per_centr_segm, 32))
     centr_segm_n = min(centr_segm_n, 1000)
 
-    logger.info(f'Preparing {centr_n} centroids for {centr_segm_n} segments')
-
-    def segment_centr_df(results, ibm_cos):
-        centr_df = pd.concat(results)
-        first_peak_df = centr_df[centr_df.peak_i == 0].copy()
-        segm_bounds_q = [i * 1 / centr_segm_n for i in range(0, centr_segm_n)]
-        segm_lower_bounds = list(np.quantile(first_peak_df.mz, q) for q in segm_bounds_q)
-
-        segment_mapping = np.searchsorted(segm_lower_bounds, first_peak_df.mz.values, side='right') - 1
-        first_peak_df['segm_i'] = segment_mapping
-
-        centr_segm_df = pd.merge(centr_df, first_peak_df[['formula_i', 'segm_i']],
-                                 on='formula_i').sort_values('mz')
-
-        def upload_db_segment(args):
-            segm_i, df = args
-            ibm_cos.put_object(Bucket=bucket,
-                               Key=f'{centr_segm_prefix}/{segm_i}.msgpack',
-                               Body=df.to_msgpack())
-
-        print("Segmenting centroids")
-        with ThreadPoolExecutor(max_workers=128) as pool:
-            pool.map(upload_db_segment, [(segm_i, df) for segm_i, df in centr_segm_df.groupby('segm_i')])
+    def get_first_peak_mz(bucket, key, data_stream):
+        centr_df = pd.read_msgpack(data_stream._raw_stream)
+        first_peak_df = centr_df[centr_df.peak_i == 0]
+        return first_peak_df.mz
 
     pw = pywren.ibm_cf_executor(config=config, runtime_memory=4096)
-    futures = pw.map_reduce(clip_centroids_df_per_chunk, db_prefix_bucket_key, segment_centr_df)
+    futures = pw.map(get_first_peak_mz, f'{bucket}/{clip_centr_chunk_prefix}/')
+    mz = pd.concat(pw.get_result(futures))
+    append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
+
+    segm_bounds_q = [i * 1 / centr_segm_n for i in range(0, centr_segm_n)]
+    segm_lower_bounds = list(np.quantile(mz, q) for q in segm_bounds_q)
+    db_segments = np.array(list(zip(segm_lower_bounds[:-1], segm_lower_bounds[1:])))
+
+    logger.info(f'Generated {len(db_segments)} database segments: {db_segments[0]}...{db_segments[-1]}')
+    return db_segments
+
+
+def segment_centroids(config, bucket, clip_centr_chunk_prefix, centr_segm_prefix, db_segments_bounds):
+    mz_segments = list(enumerate(db_segments_bounds))
+
+    def segment_centr_df_chunk(bucket, key, data_stream, ibm_cos):
+        ch_i = int(key.split("/")[-1].split(".msgpack")[0])
+        print(f'Segmenting centroids chunk {ch_i}')
+        centr_df = pd.read_msgpack(data_stream._raw_stream)
+
+        def _segment_spectra_chunk(args):
+            segm_i, (l, r) = args
+            ################################################################################################
+            segm_start, segm_end = np.searchsorted(centr_df[:, 1], (l, r))  # TODO: mz expected to be in column 1
+            segm = centr_df[segm_start:segm_end]
+            ibm_cos.put_object(Bucket=bucket,
+                               Key=f'{centr_segm_prefix}/chunk/{segm_i}/{ch_i}.msgpack',
+                               Body=msgpack.dumps(segm))
+
+        with ThreadPoolExecutor(max_workers=128) as pool:
+            pool.map(_segment_spectra_chunk, mz_segments)
+
+    pw = pywren.ibm_cf_executor(config=config, runtime_memory=1024)
+    futures = pw.map(segment_centr_df_chunk, f'{bucket}/{clip_centr_chunk_prefix}')
     pw.get_result(futures)
-    append_pywren_stats(futures[:-1], pw.config['pywren']['runtime_memory'])
-    append_pywren_stats(futures[-1], pw.config['pywren']['runtime_memory'])
-    logger.info(f'Segmented centroids into {centr_segm_n} segments')
+    append_pywren_stats(futures, pw.config['pywren']['runtime_memory'])
+
+    # def segment_centr_df(results, ibm_cos):
+    #     centr_df = pd.concat(results)
+    #     first_peak_df = centr_df[centr_df.peak_i == 0].copy()
+    #
+    #     segment_mapping = np.searchsorted(segm_lower_bounds, first_peak_df.mz.values, side='right') - 1
+    #     first_peak_df['segm_i'] = segment_mapping
+    #
+    #     centr_segm_df = pd.merge(centr_df, first_peak_df[['formula_i', 'segm_i']],
+    #                              on='formula_i').sort_values('mz')
+    #
+    #     def upload_db_segment(args):
+    #         segm_i, df = args
+    #         ibm_cos.put_object(Bucket=bucket,
+    #                            Key=f'{centr_segm_prefix}/{segm_i}.msgpack',
+    #                            Body=df.to_msgpack())
+    #
+    #     print("Segmenting centroids")
+    #     with ThreadPoolExecutor(max_workers=128) as pool:
+    #         pool.map(upload_db_segment, [(segm_i, df) for segm_i, df in centr_segm_df.groupby('segm_i')])
+    #
+    # pw = pywren.ibm_cf_executor(config=config, runtime_memory=4096)
+    # futures = pw.map_reduce(clip_centroids_df_per_chunk, f'{bucket}/{centr_chunks_prefix}/', segment_centr_df)
+    # pw.get_result(futures)
+    # append_pywren_stats(futures[:-1], pw.config['pywren']['runtime_memory'])
+    # append_pywren_stats(futures[-1], pw.config['pywren']['runtime_memory'])
+    # logger.info(f'Segmented centroids into {centr_segm_n} segments')
 
     return centr_n, centr_segm_n

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -12,6 +12,7 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -12,6 +12,7 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_huge2.json
+++ b/metabolomics/input_config_huge2.json
@@ -12,6 +12,7 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_huge3.json
+++ b/metabolomics/input_config_huge3.json
@@ -12,6 +12,7 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -12,6 +12,7 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
+    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
     "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",


### PR DESCRIPTION
Regarding to huge2 and huge3 datasets, we need a different logic for the part that sorts all relevant centroids together.
With this patch, any size of centroids database will be supported.

Notice that currently, this implementation works with **PyWren version 1.0.17**, I will submit another PR to adjust the project with the most up to date PyWren version and with its new features.