### PR TITLE
Fix OUTATIME in read_ds_segment

### DIFF
--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -106,13 +106,17 @@ def gen_iso_images(sp_inds, sp_mzs, sp_ints, centr_df, nrows, ncols, ppm=3, min_
 def read_ds_segments(ds_bucket, ds_segm_prefix, first_segm_i, last_segm_i, ibm_cos):
 
     def read_ds_segment(ds_segm_key):
-        data_stream = ibm_cos.get_object(Bucket=ds_bucket, Key=ds_segm_key)['Body']
         data = None
+        attempts = 1
         while data is None:
             try:
+                data_stream = ibm_cos.get_object(Bucket=ds_bucket, Key=ds_segm_key)['Body']
                 data = msgpack.loads(data_stream.read())
-            except:
-                pass
+            except Exception as e:
+                print(e)
+                if attempts >= 5:
+                    raise
+                attempts += 1
 
         if type(data) == list:
             sp_arr = np.concatenate(data)


### PR DESCRIPTION
Due to the infinite while loop and try/catch, the action would loop forever if `data_stream` was broken. 2-4 out of 1114 actions would regularly fail for me at this stage, running until they timeout.

I moved `data_stream` into the `try` block so that if there's an exception, the next attempt will get a new `data_stream` that shouldn't be broken.

I limited it to 5 attempts so that even if every attempt times out, the action still should finish in less than 10 minutes instead of being killed. I also print the exceptions so that they're logged. Hopefully these will help debugging if there are future issues.