### PR TITLE
Dynamic annotate() memory

### DIFF
--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -10,7 +10,7 @@ from annotation_pipeline.segment import ISOTOPIC_PEAK_N
 
 
 class ImagesManager:
-    min_memory_allowed = 256 * 1024 ** 2  # 256MB
+    min_memory_allowed = 128 * 1024 ** 2  # 128MB
 
     def __init__(self, internal_storage, bucket, max_formula_images_size):
         if max_formula_images_size < self.__class__.min_memory_allowed:

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -3,7 +3,6 @@ import pandas as pd
 from scipy.sparse import coo_matrix
 from concurrent.futures import ThreadPoolExecutor
 import msgpack_numpy as msgpack
-from ibm_botocore.exceptions import ReadTimeoutError
 
 from annotation_pipeline.utils import ds_dims, get_pixel_indices
 from annotation_pipeline.validate import make_compute_image_metrics, formula_image_metrics
@@ -11,14 +10,18 @@ from annotation_pipeline.segment import ISOTOPIC_PEAK_N
 
 
 class ImagesManager:
-    max_formula_images_size = 256 * 1024 ** 2  # 256MB
+    min_memory_allowed = 256 * 1024 ** 2  # 256MB
 
-    def __init__(self, internal_storage, bucket):
+    def __init__(self, internal_storage, bucket, max_formula_images_size):
+        if max_formula_images_size < self.__class__.min_memory_allowed:
+            raise Exception(f'There isn\'t enough memory to generate images, consider increasing PyWren\'s memory.')
+
         self.formula_metrics = {}
         self.formula_images = {}
         self.cloud_objs = []
 
         self._formula_images_size = 0
+        self._max_formula_images_size = max_formula_images_size
         self._internal_storage = internal_storage
         self._bucket = bucket
         self._partition = 0
@@ -34,7 +37,7 @@ class ImagesManager:
     def add_f_images(self, f_i, f_images):
         self.formula_images[f_i] = f_images
         self._formula_images_size += ImagesManager.images_size(f_images)
-        if self._formula_images_size > self.__class__.max_formula_images_size:
+        if self._formula_images_size > self._max_formula_images_size:
             self.save_images()
             self.formula_images.clear()
             self._formula_images_size = 0
@@ -159,7 +162,7 @@ def choose_ds_segments(ds_segments_bounds, centr_df, ppm):
 
 
 def create_process_segment(ds_bucket, output_bucket, ds_segm_prefix, ds_segments_bounds,
-                           coordinates, image_gen_config):
+                           coordinates, image_gen_config, pw_mem_mb, ds_segm_size_mb):
     sample_area_mask = make_sample_area_mask(coordinates)
     nrows, ncols = ds_dims(coordinates)
     compute_metrics = make_compute_image_metrics(sample_area_mask, nrows, ncols, image_gen_config)
@@ -177,7 +180,10 @@ def create_process_segment(ds_bucket, output_bucket, ds_segm_prefix, ds_segments
 
         formula_images_it = gen_iso_images(sp_inds=sp_arr[:,0], sp_mzs=sp_arr[:,1], sp_ints=sp_arr[:,2],
                                            centr_df=centr_df, nrows=nrows, ncols=ncols, ppm=ppm, min_px=1)
-        images_manager = ImagesManager(internal_storage, output_bucket)
+        safe_mb = 1024
+        max_formula_images_mb = (pw_mem_mb - safe_mb - (last_ds_segm_i - first_ds_segm_i + 1) * ds_segm_size_mb) // 2
+        print(f'max_formula_images_mb: {max_formula_images_mb}')
+        images_manager = ImagesManager(internal_storage, output_bucket, max_formula_images_mb * 1024 ** 2)
         formula_image_metrics(formula_images_it, compute_metrics, images_manager)
         images_cloud_objs = images_manager.finish()
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -83,7 +83,9 @@ class Pipeline(object):
         process_centr_segment = create_process_segment(self.config["storage"]["ds_bucket"],
                                                        self.config["storage"]["output_bucket"],
                                                        self.input_data["ds_segments"],
-                                                       self.ds_segments_bounds, self.coordinates, self.image_gen_config)
+                                                       self.ds_segments_bounds, self.coordinates, self.image_gen_config,
+                                                       self.pywren_executor.config['pywren']['runtime_memory'],
+                                                       self.ds_segm_size_mb)
 
         futures = self.pywren_executor.map(process_centr_segment, f'{self.config["storage"]["db_bucket"]}/{self.input_db["centroids_segments"]}/')
         formula_metrics_list, images_cloud_objs = zip(*self.pywren_executor.get_result(futures))

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -2,7 +2,6 @@ import logging
 from pathlib import Path
 import numpy as np
 import ibm_boto3
-from ibm_botocore.client import Config
 import pandas as pd
 import os
 
@@ -20,8 +19,8 @@ logger = logging.getLogger('annotation-pipeline')
 
 def get_ibm_cos_client(config):
     return ibm_boto3.client(service_name='s3',
-                            ibm_api_key_id=config['ibm_cos']['api_key'],
-                            config=Config(signature_version='oauth'),
+                            aws_access_key_id=config['ibm_cos']['access_key'],
+                            aws_secret_access_key=config['ibm_cos']['secret_key'],
                             endpoint_url=config['ibm_cos']['endpoint'])
 
 

--- a/config.json.template
+++ b/config.json.template
@@ -6,7 +6,9 @@
   },
   "ibm_cos": {
     "endpoint": "https://s3.****.cloud-object-storage.appdomain.cloud",
-    "api_key": "****"
+    "private_endpoint": "https://s3.private.****.cloud-object-storage.appdomain.cloud",
+    "access_key": "****",
+    "secret_key": "****"
   },
   "pywren": {
     "storage_bucket": "****",


### PR DESCRIPTION
**main changes**:
- with previous `annotate` we set the maximum memory of `formula_images` statically by a const value regardless of the action's context. now, each action calculates its own `formula_images` maximum memory. if the action calculates too small max memory (a const predefined bytes number), it will raise an exception.
- change the config file template for secret key and access key instead of api_key to avoid "token expired" issues