### PR TITLE
Fix first level segmentation and memory optimization

### DIFF
--- a/annotation_pipeline/fdr.py
+++ b/annotation_pipeline/fdr.py
@@ -6,7 +6,7 @@ import msgpack_numpy as msgpack
 
 from annotation_pipeline.formula_parser import safe_generate_ion_formula
 from annotation_pipeline.molecular_db import DECOY_ADDUCTS
-from annotation_pipeline.utils import append_pywren_stats, read_object_with_retry
+from annotation_pipeline.utils import append_pywren_stats, read_object_with_retry, list_keys
 
 
 def _get_random_adduct_set(size, adducts, offset):
@@ -41,9 +41,7 @@ def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
             mol_formulas = list(map(safe_generate_ion_formula, mols, repeat(modifier), adducts))
 
         formula_to_id = {}
-        objs = ibm_cos.list_objects_v2(Bucket=bucket,
-                                       Prefix=f'{input_db["formula_to_id_chunks"]}/')
-        keys = [obj['Key'] for obj in objs['Contents']]
+        keys = list_keys(bucket, f'{input_db["formula_to_id_chunks"]}/', ibm_cos)
         for key in keys:
             formula_to_id_chunk = read_object_with_retry(ibm_cos, bucket, key, msgpack_load_text)
 
@@ -79,7 +77,7 @@ def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
         ranking_jobs.extend((group_i, ranking_i, database, modifier, None)
                              for ranking_i in range(n_decoy_rankings))
 
-    futures = pw.map(build_ranking, ranking_jobs)
+    futures = pw.map(build_ranking, ranking_jobs, runtime_memory=1024)
     ranking_keys = [key for job_i, key in sorted(pw.get_result(futures))]
     append_pywren_stats(futures, memory=pw.config['pywren']['runtime_memory'], plus_objects=len(futures))
 
@@ -129,7 +127,7 @@ def calculate_fdrs(pw, data_bucket, rankings_df):
         for i, target_row in target_rows.iterrows():
             ranking_jobs.append([data_bucket, target_row, decoy_rows.key.tolist()])
 
-    futures = pw.map(merge_rankings, ranking_jobs)
+    futures = pw.map(merge_rankings, ranking_jobs, runtime_memory=128)
     results = pw.get_result(futures)
     append_pywren_stats(futures, memory=pw.config['pywren']['runtime_memory'])
 

--- a/annotation_pipeline/fdr.py
+++ b/annotation_pipeline/fdr.py
@@ -77,7 +77,7 @@ def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
         ranking_jobs.extend((group_i, ranking_i, database, modifier, None)
                              for ranking_i in range(n_decoy_rankings))
 
-    memory_capacity_mb = 1024
+    memory_capacity_mb = 1536
     futures = pw.map(build_ranking, ranking_jobs, runtime_memory=memory_capacity_mb)
     ranking_keys = [key for job_i, key in sorted(pw.get_result(futures))]
     append_pywren_stats(futures, memory=memory_capacity_mb, plus_objects=len(futures))

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -137,14 +137,16 @@ def read_ds_segments(ds_bucket, ds_segm_prefix, first_segm_i, last_segm_i, ds_se
             sub_sp_arr = read_ds_segment(key)
             sp_arr[row_i:row_i + len(sub_sp_arr)] = sub_sp_arr
             row_i += len(sub_sp_arr)
+        sp_arr.view(f'{ds_segm_dtype},{ds_segm_dtype},{ds_segm_dtype}').sort(order=['f1'],
+                                                                             axis=0)  # assume mz in column 1
 
     else:
 
         with ThreadPoolExecutor(max_workers=128) as pool:
             sp_arr = list(pool.map(read_ds_segment, ds_segm_keys))
         sp_arr = np.concatenate(sp_arr)
+        sp_arr = sp_arr[sp_arr[:, 1].argsort()]  # assume mz in column 1
 
-    sp_arr.view(f'{ds_segm_dtype},{ds_segm_dtype},{ds_segm_dtype}').sort(order=['f1'], axis=0)  # assume mz in column 1
     return sp_arr
 
 

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -11,7 +11,7 @@ from annotation_pipeline.segment import ISOTOPIC_PEAK_N
 
 
 class ImagesManager:
-    min_memory_allowed = 128 * 1024 ** 2  # 128MB
+    min_memory_allowed = 64 * 1024 ** 2  # 64MB
 
     def __init__(self, internal_storage, bucket, max_formula_images_size):
         if max_formula_images_size < self.__class__.min_memory_allowed:
@@ -195,7 +195,7 @@ def create_process_segment(ds_bucket, output_bucket, ds_segm_prefix, ds_segments
         formula_images_it = gen_iso_images(sp_inds=sp_arr[:,0], sp_mzs=sp_arr[:,1], sp_ints=sp_arr[:,2],
                                            centr_df=centr_df, nrows=nrows, ncols=ncols, ppm=ppm, min_px=1)
         safe_mb = 1024
-        max_formula_images_mb = (pw_mem_mb - safe_mb - (last_ds_segm_i - first_ds_segm_i + 1) * ds_segm_size_mb) // 2
+        max_formula_images_mb = (pw_mem_mb - safe_mb - (last_ds_segm_i - first_ds_segm_i + 1) * ds_segm_size_mb) // 3
         print(f'Max formula_images size: {max_formula_images_mb} mb')
         images_manager = ImagesManager(internal_storage, output_bucket, max_formula_images_mb * 1024 ** 2)
         formula_image_metrics(formula_images_it, compute_metrics, images_manager)

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -1,3 +1,4 @@
+import pickle
 import numpy as np
 import pandas as pd
 from scipy.sparse import coo_matrix
@@ -48,7 +49,7 @@ class ImagesManager:
     def save_images(self):
         if self.formula_images:
             print(f'Saving {len(self.formula_images)} images')
-            cloud_obj = self._internal_storage.put_object(self.formula_images, bucket=self._bucket)
+            cloud_obj = self._internal_storage.put_object(pickle.dumps(self.formula_images), bucket=self._bucket)
             self.cloud_objs.append(cloud_obj)
             self._partition += 1
         else:

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -10,7 +10,8 @@ import hashlib
 import math
 
 from annotation_pipeline.formula_parser import safe_generate_ion_formula
-from annotation_pipeline.utils import logger, get_ibm_cos_client, append_pywren_stats, clean_from_cos, read_object_with_retry
+from annotation_pipeline.utils import logger, get_ibm_cos_client, append_pywren_stats, list_keys, clean_from_cos,\
+    read_object_with_retry
 
 DECOY_ADDUCTS = ['+He', '+Li', '+Be', '+B', '+C', '+N', '+O', '+F', '+Ne', '+Mg', '+Al', '+Si', '+P', '+S', '+Cl', '+Ar', '+Ca', '+Sc', '+Ti', '+V', '+Cr', '+Mn', '+Fe', '+Co', '+Ni', '+Cu', '+Zn', '+Ga', '+Ge', '+As', '+Se', '+Br', '+Kr', '+Rb', '+Sr', '+Y', '+Zr', '+Nb', '+Mo', '+Ru', '+Rh', '+Pd', '+Ag', '+Cd', '+In', '+Sn', '+Sb', '+Te', '+I', '+Xe', '+Cs', '+Ba', '+La', '+Ce', '+Pr', '+Nd', '+Sm', '+Eu', '+Gd', '+Tb', '+Dy', '+Ho', '+Ir', '+Th', '+Pt', '+Os', '+Yb', '+Lu', '+Bi', '+Pb', '+Re', '+Tl', '+Tm', '+U', '+W', '+Au', '+Er', '+Hf', '+Hg', '+Ta']
 N_FORMULAS_SEGMENTS = 256
@@ -77,8 +78,7 @@ def build_database(config, input_db):
 
     def deduplicate_formulas_segment(segm_i, ibm_cos, clean=True):
         print(f'Deduplicating formulas segment {segm_i}')
-        objs = ibm_cos.list_objects_v2(Bucket=bucket, Prefix=f'{formulas_chunks_prefix}/chunk/{segm_i}/')
-        keys = [obj['Key'] for obj in objs['Contents']] if 'Contents' in objs else []
+        keys = list_keys(bucket, f'{formulas_chunks_prefix}/chunk/{segm_i}/', ibm_cos)
 
         segm = set()
         for key in keys:

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -82,19 +82,19 @@ class Pipeline(object):
         logger.info('Annotating...')
         clean_from_cos(self.config, self.config["storage"]["output_bucket"], self.output["formula_images"])
 
+        memory_capacity_mb = 2048
         process_centr_segment = create_process_segment(self.config["storage"]["ds_bucket"],
                                                        self.config["storage"]["output_bucket"],
                                                        self.input_data["ds_segments"],
                                                        self.ds_segments_bounds, self.coordinates, self.image_gen_config,
-                                                       self.pywren_executor.config['pywren']['runtime_memory'],
-                                                       self.ds_segm_size_mb)
+                                                       memory_capacity_mb, self.ds_segm_size_mb)
 
-        futures = self.pywren_executor.map(process_centr_segment, f'{self.config["storage"]["db_bucket"]}/{self.input_db["centroids_segments"]}/')
+        futures = self.pywren_executor.map(process_centr_segment, f'{self.config["storage"]["db_bucket"]}/{self.input_db["centroids_segments"]}/',
+                                           runtime_memory=memory_capacity_mb)
         formula_metrics_list, images_cloud_objs = zip(*self.pywren_executor.get_result(futures))
         self.formula_metrics_df = pd.concat(formula_metrics_list)
         self.images_cloud_objs = np.concatenate(images_cloud_objs)
-        append_pywren_stats(futures, memory=self.pywren_executor.config['pywren']['runtime_memory'],
-                            plus_objects=len(self.images_cloud_objs))
+        append_pywren_stats(futures, memory=memory_capacity_mb, plus_objects=len(self.images_cloud_objs))
 
         logger.info(f'Metrics calculated: {self.formula_metrics_df.shape[0]}')
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -53,10 +53,12 @@ class Pipeline(object):
 
     def segment_ds(self):
         clean_from_cos(self.config, self.config["storage"]["ds_bucket"], self.input_data["ds_segments"])
-        self.ds_segments_bounds = define_ds_segments(self.imzml_parser, self.ds_segm_size_mb, sample_ratio=0.05)
+        sample_sp_n = 1000
+        self.ds_segments_bounds = define_ds_segments(self.imzml_parser, self.ds_segm_size_mb,
+                                                     sample_ratio=sample_sp_n / self.sp_n)
         self.ds_segm_n = segment_spectra(self.pywren_executor, self.config["storage"]["ds_bucket"],
                                          self.input_data["ds_chunks"], self.input_data["ds_segments"],
-                                         self.ds_segments_bounds)
+                                         self.ds_segments_bounds, self.ds_segm_size_mb)
         logger.info(f'Segmented dataset chunks into {self.ds_segm_n} segments')
 
     def segment_centroids(self):

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -56,9 +56,9 @@ class Pipeline(object):
         sample_sp_n = 1000
         self.ds_segments_bounds = define_ds_segments(self.imzml_parser, self.ds_segm_size_mb,
                                                      sample_ratio=sample_sp_n / self.sp_n)
-        self.ds_segm_n = segment_spectra(self.pywren_executor, self.config["storage"]["ds_bucket"],
-                                         self.input_data["ds_chunks"], self.input_data["ds_segments"],
-                                         self.ds_segments_bounds, self.ds_segm_size_mb)
+        self.ds_segm_n, self.ds_segms_len = segment_spectra(self.pywren_executor, self.config["storage"]["ds_bucket"],
+                                            self.input_data["ds_chunks"], self.input_data["ds_segments"],
+                                            self.ds_segments_bounds, self.ds_segm_size_mb, self.imzml_parser.mzPrecision)
         logger.info(f'Segmented dataset chunks into {self.ds_segm_n} segments')
 
     def segment_centroids(self):
@@ -86,8 +86,9 @@ class Pipeline(object):
         process_centr_segment = create_process_segment(self.config["storage"]["ds_bucket"],
                                                        self.config["storage"]["output_bucket"],
                                                        self.input_data["ds_segments"],
-                                                       self.ds_segments_bounds, self.coordinates, self.image_gen_config,
-                                                       memory_capacity_mb, self.ds_segm_size_mb)
+                                                       self.ds_segments_bounds, self.ds_segms_len, self.coordinates,
+                                                       self.image_gen_config, memory_capacity_mb, self.ds_segm_size_mb,
+                                                       self.imzml_parser.mzPrecision)
 
         futures = self.pywren_executor.map(process_centr_segment, f'{self.config["storage"]["db_bucket"]}/{self.input_db["centroids_segments"]}/',
                                            runtime_memory=memory_capacity_mb)

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -151,7 +151,10 @@ def segment_spectra(pw, bucket, ds_chunks_prefix, ds_segments_prefix, ds_segment
             segm = list(pool.map(_merge, keys))
 
         segm = np.concatenate(segm)
-        segm.view(f'{segm_dtype},{segm_dtype},{segm_dtype}').sort(order=['f1'], axis=0)
+
+        # Alternative in-place sorting (slower) :
+        # segm.view(f'{segm_dtype},{segm_dtype},{segm_dtype}').sort(order=['f1'], axis=0)
+        segm = segm[segm[:, 1].argsort()]
 
         clean_from_cos(None, bucket, f'{ds_segments_prefix}/chunk/{segm_i}/', ibm_cos)
         bounds_list = ds_segments_bounds[segm_i]

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -3,6 +3,7 @@ from pathlib import Path
 from datetime import datetime
 import numpy as np
 import ibm_boto3
+import ibm_botocore
 import pandas as pd
 import csv
 
@@ -22,10 +23,15 @@ STATUS_PATH = datetime.now().strftime("logs/%Y-%m-%d_%H:%M:%S.csv")
 
 
 def get_ibm_cos_client(config):
+    client_config = ibm_botocore.client.Config(connect_timeout=1,
+                                               read_timeout=3,
+                                               retries={'max_attempts': 5})
+
     return ibm_boto3.client(service_name='s3',
                             aws_access_key_id=config['ibm_cos']['access_key'],
                             aws_secret_access_key=config['ibm_cos']['secret_key'],
-                            endpoint_url=config['ibm_cos']['endpoint'])
+                            endpoint_url=config['ibm_cos']['endpoint'],
+                            config=client_config)
 
 
 def upload_to_cos(cos_client, src, target_bucket, target_key):

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -59,8 +59,8 @@ def clean_from_cos(config, bucket, prefix, cos_client=None):
         keys = [obj['Key'] for obj in objs['Contents']]
         formatted_keys = {'Objects': [{'Key': key} for key in keys]}
         cos_client.delete_objects(Bucket=bucket, Delete=formatted_keys)
-        objs = cos_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
         removed_keys_n += objs["KeyCount"]
+        objs = cos_client.list_objects_v2(Bucket=bucket, Prefix=prefix)
 
     logger.info(f'Removed {removed_keys_n} objects from {prefix}')
 

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='pywren-annotation-pipeline',
       url='https://github.com/metaspace2020/pywren-annotation-pipeline',
       packages=find_packages(),
       install_requires=[
-          "pywren-ibm-cloud>=1.1.0",
+          "pywren-ibm-cloud>=1.4.3",
           # pandas version should match the version in the runtime to ensure data generated locally can be unpickled
           # in pywren actions
           "pandas==0.25.1",


### PR DESCRIPTION
**main changes:**
- fix first level dataset segmentation to generate bounded "first-level-segment" in terms of memory. the previous version used hard-coded first-level segments number (32), now it is calculated dynamically by `first_level_segm_size_mb` - issue #58 
- optimize annotate function to use pre-allocated concatenation if there isn't enough memory to use parallel read and np.concatenate.
- reduce memory capacity for all PyWren calls to reduce the total price
- add `list_keys()` method to get a list of keys with a specific prefix - can list more than 1000 keys rather than before.
- improve `sample_ratio` to be calculated dynamically to sample 1000 spectra lines instead of 5%.
- minor change for `ImagesManager` class to be aligned with PyWren 1.4.3