### PR TITLE
Add support in cloud objects for Pipeline

### DIFF
--- a/annotation_pipeline/fdr.py
+++ b/annotation_pipeline/fdr.py
@@ -54,15 +54,12 @@ def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
         if adduct is not None:
             ranking_df = pd.DataFrame({'mol': mols, 'msm': msm}, index=formula_is)
             ranking_df = ranking_df[~ranking_df.msm.isna()]
-            key = f'{input_data["fdr_rankings"]}/{group_i}/target{ranking_i}.pickle'
         else:
             # Specific molecules don't matter in the decoy rankings, only their msm distribution
             ranking_df = pd.DataFrame({'msm': msm})
             ranking_df = ranking_df[~ranking_df.msm.isna()]
-            key = f'{input_data["fdr_rankings"]}/{group_i}/decoy{ranking_i}.pickle'
 
-        storage.put_object(Bucket=bucket, Key=key, Body=pickle.dumps(ranking_df))
-        return id, key
+        return id, storage.put_cobject(pickle.dumps(ranking_df))
 
     decoy_adducts = sorted(set(DECOY_ADDUCTS).difference(input_db['adducts']))
     n_decoy_rankings = input_data.get('num_decoys', len(decoy_adducts))
@@ -79,20 +76,20 @@ def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
 
     memory_capacity_mb = 1536
     futures = pw.map(build_ranking, ranking_jobs, runtime_memory=memory_capacity_mb)
-    ranking_keys = [key for job_i, key in sorted(pw.get_result(futures))]
+    ranking_cobjects = [cobject for job_i, cobject in sorted(pw.get_result(futures))]
     append_pywren_stats(futures, memory_mb=memory_capacity_mb, plus_objects=len(futures))
 
     rankings_df = pd.DataFrame(ranking_jobs, columns=['group_i', 'ranking_i', 'database_path', 'modifier', 'adduct'])
-    rankings_df = rankings_df.assign(is_target=~rankings_df.adduct.isnull(), key=ranking_keys)
+    rankings_df = rankings_df.assign(is_target=~rankings_df.adduct.isnull(), cobject=ranking_cobjects)
 
     return rankings_df
 
 
-def calculate_fdrs(pw, data_bucket, rankings_df):
+def calculate_fdrs(pw, rankings_df):
 
-    def run_ranking(storage, data_bucket, target_key, decoy_key):
-        target = pickle.loads(read_object_with_retry(storage, data_bucket, target_key))
-        decoy = pickle.loads(read_object_with_retry(storage, data_bucket, decoy_key))
+    def run_ranking(target_cobject, decoy_cobject, storage):
+        target = pickle.loads(storage.get_cobject(target_cobject))
+        decoy = pickle.loads(storage.get_cobject(decoy_cobject))
         merged = pd.concat([target.assign(is_target=1), decoy.assign(is_target=0)], sort=False)
         merged = merged.sort_values('msm', ascending=False)
         decoy_cumsum = (merged.is_target == False).cumsum()
@@ -106,10 +103,10 @@ def calculate_fdrs(pw, data_bucket, rankings_df):
         target_fdrs = target_fdrs.sort_index()
         return target_fdrs
 
-    def merge_rankings(storage, data_bucket, target_row, decoy_keys):
+    def merge_rankings(target_row, decoy_cobjects, storage):
         print("Merging rankings...")
         print(target_row)
-        rankings = [run_ranking(storage, data_bucket, target_row.key, decoy_key) for decoy_key in decoy_keys]
+        rankings = [run_ranking(target_row.cobject, decoy_cobject, storage) for decoy_cobject in decoy_cobjects]
         mols = (pd.concat(rankings)
                 .rename_axis('formula_i')
                 .reset_index()
@@ -126,7 +123,7 @@ def calculate_fdrs(pw, data_bucket, rankings_df):
         decoy_rows = group[~group.is_target]
 
         for i, target_row in target_rows.iterrows():
-            ranking_jobs.append([data_bucket, target_row, decoy_rows.key.tolist()])
+            ranking_jobs.append([target_row, decoy_rows.cobject.tolist()])
 
     memory_capacity_mb = 256
     futures = pw.map(merge_rankings, ranking_jobs, runtime_memory=memory_capacity_mb)

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -176,13 +176,10 @@ def create_process_segment(ds_segms_cobjects, ds_segments_bounds, ds_segms_len,
     compute_metrics = make_compute_image_metrics(sample_area_mask, nrows, ncols, image_gen_config)
     ppm = image_gen_config['ppm']
 
-    def process_centr_segment(obj, storage):
-        print(f'Reading centroids segment {obj.key}')
+    def process_centr_segment(db_segm_cobject, id, storage):
+        print(f'Reading centroids segment {id}')
         # read database relevant part
-        try:
-            centr_df = pd.read_msgpack(obj.data_stream)
-        except:
-            centr_df = read_object_with_retry(storage, obj.bucket, obj.key, pd.read_msgpack)
+        centr_df = pd.read_msgpack(storage.get_cobject(db_segm_cobject))
 
         # find range of datasets
         first_ds_segm_i, last_ds_segm_i = choose_ds_segments(ds_segments_bounds, centr_df, ppm)
@@ -201,7 +198,7 @@ def create_process_segment(ds_segms_cobjects, ds_segments_bounds, ds_segms_len,
         formula_image_metrics(formula_images_it, compute_metrics, images_manager)
         images_cloud_objs = images_manager.finish()
 
-        print(f'Centroids segment {obj.key} finished')
+        print(f'Centroids segment {id} finished')
         formula_metrics_df = pd.DataFrame.from_dict(images_manager.formula_metrics, orient='index')
         formula_metrics_df.index.name = 'formula_i'
         return formula_metrics_df, images_cloud_objs

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -86,9 +86,7 @@ class Pipeline(object):
             memory_capacity_mb = 4096
         else:
             memory_capacity_mb = 2048
-        process_centr_segment = create_process_segment(self.config["storage"]["ds_bucket"],
-                                                       self.config["storage"]["output_bucket"],
-                                                       self.input_config_ds["ds_segments"],
+        process_centr_segment = create_process_segment(self.ds_segms_cobjects,
                                                        self.ds_segments_bounds, self.ds_segms_len, self.imzml_reader,
                                                        self.image_gen_config, memory_capacity_mb, self.ds_segm_size_mb)
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -91,7 +91,7 @@ class Pipeline(object):
                                                        self.ds_segments_bounds, self.ds_segms_len, self.imzml_reader,
                                                        self.image_gen_config, memory_capacity_mb, self.ds_segm_size_mb)
 
-        futures = self.pywren_executor.map(process_centr_segment, f'{self.config["storage"]["db_bucket"]}/{self.input_config_db["centroids_segments"]}/',
+        futures = self.pywren_executor.map(process_centr_segment, f'cos://{self.config["storage"]["db_bucket"]}/{self.input_config_db["centroids_segments"]}/',
                                            runtime_memory=memory_capacity_mb)
         formula_metrics_list, images_cloud_objs = zip(*self.pywren_executor.get_result(futures))
         self.formula_metrics_df = pd.concat(formula_metrics_list)
@@ -120,9 +120,9 @@ class Pipeline(object):
         # Only download interesting images, to prevent running out of memory
         targets = set(self.results_df.index[self.results_df.fdr <= 0.5])
 
-        def get_target_images(internal_storage, images_obj):
+        def get_target_images(images_obj, storage):
             images = {}
-            segm_images = pickle.loads(internal_storage.get_object(images_obj))
+            segm_images = pickle.loads(storage.get_cobject(images_obj))
             for k, v in segm_images.items():
                 if k in targets:
                     images[k] = v

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -185,13 +185,13 @@ class Pipeline(object):
 
     def clean(self):
         cobjects_to_clean = []
-        cobjects_to_clean.append(self.imzml_cobject)
-        cobjects_to_clean.extend(self.ds_chunks_cobjects)
-        cobjects_to_clean.extend(self.ds_segms_cobjects)
-        cobjects_to_clean.extend(self.clip_centr_chunks_cobjects)
-        cobjects_to_clean.extend(self.db_segms_cobjects)
-        cobjects_to_clean.extend(self.images_cloud_objs)
-        cobjects_to_clean.extend(self.rankings_df.cobject.tolist())
+        if hasattr(self, 'imzml_cobject'): cobjects_to_clean.append(self.imzml_cobject)
+        if hasattr(self, 'ds_chunks_cobjects'): cobjects_to_clean.extend(self.ds_chunks_cobjects)
+        if hasattr(self, 'ds_segms_cobjects'): cobjects_to_clean.extend(self.ds_segms_cobjects)
+        if hasattr(self, 'clip_centr_chunks_cobjects'): cobjects_to_clean.extend(self.clip_centr_chunks_cobjects)
+        if hasattr(self, 'db_segms_cobjects'): cobjects_to_clean.extend(self.db_segms_cobjects)
+        if hasattr(self, 'images_cloud_objs'): cobjects_to_clean.extend(self.images_cloud_objs)
+        if hasattr(self, 'rankings_df'): cobjects_to_clean.extend(self.rankings_df.cobject.tolist())
 
         self.pywren_executor.clean(cs=cobjects_to_clean)
         shutil.rmtree(self.cache_path)

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -47,7 +47,7 @@ class Pipeline(object):
 
     def split_ds(self):
         clean_from_cos(self.config, self.config["storage"]["ds_bucket"], self.input_config_ds["ds_chunks"])
-        chunk_spectra(self.pywren_executor, self.config, self.input_config_ds, self.imzml_reader)
+        self.ds_chunks_cobjects = chunk_spectra(self.pywren_executor, self.config, self.input_config_ds, self.imzml_reader)
 
     def segment_ds(self):
         clean_from_cos(self.config, self.config["storage"]["ds_bucket"], self.input_config_ds["ds_segments"])
@@ -58,8 +58,7 @@ class Pipeline(object):
                                                      self.input_config_ds["ds_imzml_reader"],
                                                      self.ds_segm_size_mb, sample_sp_n)
         self.ds_segms_cobjects, self.ds_segms_len = \
-            segment_spectra(self.pywren_executor, self.config["storage"]["ds_bucket"],
-                            self.input_config_ds["ds_chunks"], self.ds_segments_bounds, self.ds_segm_size_mb)
+            segment_spectra(self.pywren_executor, self.ds_chunks_cobjects, self.ds_segments_bounds, self.ds_segm_size_mb)
         self.ds_segm_n = len(self.ds_segms_cobjects)
         logger.info(f'Segmented dataset chunks into {self.ds_segm_n} segments')
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -99,7 +99,7 @@ class Pipeline(object):
     def run_fdr(self):
         self.rankings_df = build_fdr_rankings(self.pywren_executor, self.config["storage"]["db_bucket"],
                                               self.input_config_ds, self.input_config_db, self.formula_metrics_df)
-        self.fdrs = calculate_fdrs(self.pywren_executor, self.config['storage']['ds_bucket'], self.rankings_df)
+        self.fdrs = calculate_fdrs(self.pywren_executor, self.rankings_df)
 
         logger.info(f'Number of annotations at with FDR less than:')
         for fdr_step in [0.05, 0.1, 0.2, 0.5]:

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -57,9 +57,10 @@ class Pipeline(object):
                                                      self.config["storage"]["ds_bucket"],
                                                      self.input_config_ds["ds_imzml_reader"],
                                                      self.ds_segm_size_mb, sample_sp_n)
-        self.ds_segm_n, self.ds_segms_len = segment_spectra(self.pywren_executor, self.config["storage"]["ds_bucket"],
-                                                            self.input_config_ds["ds_chunks"], self.input_config_ds["ds_segments"],
-                                                            self.ds_segments_bounds, self.ds_segm_size_mb, self.imzml_reader.mzPrecision)
+        self.ds_segms_cobjects, self.ds_segms_len = \
+            segment_spectra(self.pywren_executor, self.config["storage"]["ds_bucket"],
+                            self.input_config_ds["ds_chunks"], self.ds_segments_bounds, self.ds_segm_size_mb)
+        self.ds_segm_n = len(self.ds_segms_cobjects)
         logger.info(f'Segmented dataset chunks into {self.ds_segm_n} segments')
 
     def segment_centroids(self):

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -336,7 +336,7 @@ def segment_centroids(pw, clip_centr_chunks_cobjects, centr_segm_lower_bounds):
             print(f'Storing centroids segment {segm_i}')
             return storage.put_cobject(df.to_msgpack())
 
-        with ThreadPoolExecutor(max_workers=1) as pool:
+        with ThreadPoolExecutor(max_workers=128) as pool:
             segms = [(segm_i, df) for segm_i, df in centr_segm_df.groupby('segm_i')]
             segms_cobjects = list(pool.map(_second_level_upload, segms))
 

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -7,8 +7,8 @@ import sys
 import requests
 from pyimzml.ImzMLParser import ImzMLParser
 
-from annotation_pipeline.utils import logger, get_pixel_indices, append_pywren_stats, list_keys, \
-    clean_from_cos, read_object_with_retry, read_ranges_from_url
+from annotation_pipeline.utils import logger, get_pixel_indices, append_pywren_stats, read_object_with_retry, \
+    read_ranges_from_url
 from concurrent.futures import ThreadPoolExecutor
 import msgpack_numpy as msgpack
 
@@ -114,7 +114,6 @@ def chunk_spectra(pw, config, input_data, imzml_reader):
     ds_chunks_cobjects = pw.get_result(futures)
     append_pywren_stats(futures, memory_mb=memory_capacity_mb, plus_objects=len(chunks))
 
-    logger.info(f'Uploaded {len(chunks)} dataset chunks')
     return ds_chunks_cobjects
 
 
@@ -142,7 +141,6 @@ def define_ds_segments(pw, ibd_url, bucket, ds_imzml_reader, ds_segm_size_mb, sa
     future = pw.call_async(get_segm_bounds, [], runtime_memory=memory_capacity_mb)
     ds_segments = pw.get_result(future)
     append_pywren_stats(future, memory_mb=memory_capacity_mb)
-    logger.info(f'Generated {len(ds_segments)} dataset bounds: {ds_segments[0]}...{ds_segments[-1]}')
     return ds_segments
 
 

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -7,6 +7,7 @@ import ibm_boto3
 import ibm_botocore
 import pandas as pd
 import csv
+import pickle
 
 import requests
 
@@ -185,3 +186,11 @@ def read_ranges_from_url(url, ranges):
 
     return [request_results[request_i][request_lo:request_hi]
             for input_i, request_i, request_lo, request_hi in sorted(tasks)]
+
+
+def load_from_cache(path):
+    return pickle.load(open(path, 'rb'))
+
+
+def save_to_cache(data, path):
+    pickle.dump(data, open(path, 'wb'))

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -129,12 +129,12 @@ def get_pywren_stats(log_path=STATUS_PATH):
     return stats
 
 
-def read_object_with_retry(ibm_cos, bucket, key, stream_reader=None):
+def read_object_with_retry(storage, bucket, key, stream_reader=None):
     last_exception = None
     for attempt in range(1, 4):
         try:
             print(f'Reading {key} (attempt {attempt})')
-            data_stream = ibm_cos.get_object(Bucket=bucket, Key=key)['Body']
+            data_stream = storage.get_object(Bucket=bucket, Key=key)['Body']
             if stream_reader:
                 data = stream_reader(data_stream)
             else:

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -429,9 +429,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.utils import clean_from_cos\n",
-    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], \"metabolomics/tmp\")\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], \"metabolomics/tmp\")"
+    "pipeline.clean()"
    ]
   }
  ],
@@ -453,6 +451,15 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.7"
   },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  },
   "stem_cell": {
    "cell_type": "raw",
    "metadata": {
@@ -461,15 +468,6 @@
     }
    },
    "source": ""
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
   }
  },
  "nbformat": 4,

--- a/experiment-2-interactive.ipynb
+++ b/experiment-2-interactive.ipynb
@@ -298,9 +298,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.utils import clean_from_cos\n",
-    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], \"metabolomics/tmp\")\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], \"metabolomics/tmp\")"
+    "pipeline.clean()"
    ]
   }
  ],
@@ -322,6 +320,15 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.7"
   },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  },
   "stem_cell": {
    "cell_type": "raw",
    "metadata": {
@@ -330,15 +337,6 @@
     }
    },
    "source": ""
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
   }
  },
  "nbformat": 4,

--- a/experiment-3-large.ipynb
+++ b/experiment-3-large.ipynb
@@ -263,9 +263,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.utils import clean_from_cos\n",
-    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], \"metabolomics/tmp\")\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], \"metabolomics/tmp\")"
+    "pipeline.clean()"
    ]
   }
  ],
@@ -287,6 +285,15 @@
    "pygments_lexer": "ipython3",
    "version": "3.6.7"
   },
+  "pycharm": {
+   "stem_cell": {
+    "cell_type": "raw",
+    "metadata": {
+     "collapsed": false
+    },
+    "source": []
+   }
+  },
   "stem_cell": {
    "cell_type": "raw",
    "metadata": {
@@ -295,15 +302,6 @@
     }
    },
    "source": ""
-  },
-  "pycharm": {
-   "stem_cell": {
-    "cell_type": "raw",
-    "source": [],
-    "metadata": {
-     "collapsed": false
-    }
-   }
   }
  },
  "nbformat": 4,

--- a/input_config.json.template
+++ b/input_config.json.template
@@ -2,10 +2,6 @@
   "dataset": {
     "imzml_path": "****.imzML",
     "ibd_path": "****.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks",
-    "ds_imzml_reader": "****.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.00123792863514,
@@ -14,8 +10,6 @@
   "molecular_db": {
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -1,11 +1,9 @@
 {
   "dataset": {
+    "name": "AZ_Rat_brains",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/AZ_Rat_brains/Image5.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/AZ_Rat_brains/Image5.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks/AZ_Rat_brains",
     "ds_imzml_reader": "metabolomics/tmp/imzml_reader/AZ_Rat_brains.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,
@@ -15,8 +13,6 @@
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "formula_to_id_chunks": "metabolomics/db/formula_to_id",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/input_config_big.json
+++ b/metabolomics/input_config_big.json
@@ -3,7 +3,6 @@
     "name": "AZ_Rat_brains",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/AZ_Rat_brains/Image5.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/AZ_Rat_brains/Image5.ibd",
-    "ds_imzml_reader": "metabolomics/tmp/imzml_reader/AZ_Rat_brains.pickle",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -1,11 +1,9 @@
 {
   "dataset": {
+    "name": "CT26_xenograft",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/CT26_xenograft/Image1_CT26.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/CT26_xenograft/Image1_CT26.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks/CT26_xenograft",
     "ds_imzml_reader": "metabolomics/tmp/imzml_reader/CT26_xenograft.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,
@@ -15,8 +13,6 @@
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "formula_to_id_chunks": "metabolomics/db/formula_to_id",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/input_config_huge.json
+++ b/metabolomics/input_config_huge.json
@@ -3,7 +3,6 @@
     "name": "CT26_xenograft",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/CT26_xenograft/Image1_CT26.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/CT26_xenograft/Image1_CT26.ibd",
-    "ds_imzml_reader": "metabolomics/tmp/imzml_reader/CT26_xenograft.pickle",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,

--- a/metabolomics/input_config_huge2.json
+++ b/metabolomics/input_config_huge2.json
@@ -1,11 +1,9 @@
 {
   "dataset": {
+    "name": "Mouse_brain",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Mouse_brain/Mouse brain test434x902_50um_10ps_imzML.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Mouse_brain/Mouse brain test434x902_50um_10ps_imzML.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks/Mouse_brain",
     "ds_imzml_reader": "metabolomics/tmp/imzml_reader/Mouse_brain.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.002476,
@@ -15,8 +13,6 @@
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "formula_to_id_chunks": "metabolomics/db/formula_to_id",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/input_config_huge2.json
+++ b/metabolomics/input_config_huge2.json
@@ -3,7 +3,6 @@
     "name": "Mouse_brain",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Mouse_brain/Mouse brain test434x902_50um_10ps_imzML.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Mouse_brain/Mouse brain test434x902_50um_10ps_imzML.ibd",
-    "ds_imzml_reader": "metabolomics/tmp/imzml_reader/Mouse_brain.pickle",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.002476,

--- a/metabolomics/input_config_huge3.json
+++ b/metabolomics/input_config_huge3.json
@@ -1,11 +1,9 @@
 {
   "dataset": {
+    "name": "X089-Mousebrain",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/X089-Mousebrain/X089-Mousebrain_842x603_12um_A25__DB.imzml",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/X089-Mousebrain/X089-Mousebrain_842x603_12um_A25__DB.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks/X089-Mousebrain",
     "ds_imzml_reader": "metabolomics/tmp/imzml_reader/X089-Mousebrain.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,
@@ -15,8 +13,6 @@
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "formula_to_id_chunks": "metabolomics/db/formula_to_id",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/input_config_huge3.json
+++ b/metabolomics/input_config_huge3.json
@@ -3,7 +3,6 @@
     "name": "X089-Mousebrain",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/X089-Mousebrain/X089-Mousebrain_842x603_12um_A25__DB.imzml",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/X089-Mousebrain/X089-Mousebrain_842x603_12um_A25__DB.ibd",
-    "ds_imzml_reader": "metabolomics/tmp/imzml_reader/X089-Mousebrain.pickle",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,

--- a/metabolomics/input_config_huge4.json
+++ b/metabolomics/input_config_huge4.json
@@ -3,7 +3,6 @@
     "name": "microbial_interaction",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/microbial_interaction/microbial_interaction.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/microbial_interaction/microbial_interaction.ibd",
-    "ds_imzml_reader": "metabolomics/tmp/imzml_reader/microbial_interaction.pickle",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,

--- a/metabolomics/input_config_huge4.json
+++ b/metabolomics/input_config_huge4.json
@@ -1,11 +1,9 @@
 {
   "dataset": {
+    "name": "microbial_interaction",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/microbial_interaction/microbial_interaction.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/microbial_interaction/microbial_interaction.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks/microbial_interaction",
     "ds_imzml_reader": "metabolomics/tmp/imzml_reader/microbial_interaction.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.001238,
@@ -15,8 +13,6 @@
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "formula_to_id_chunks": "metabolomics/db/formula_to_id",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -1,11 +1,9 @@
 {
   "dataset": {
+    "name": "Brain02_Bregma1-42_02",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.ibd",
-    "ds_chunks": "metabolomics/tmp/ds_chunks/Brain02_Bregma1-42_02",
     "ds_imzml_reader": "metabolomics/tmp/imzml_reader/Brain02_Bregma1-42_02.pickle",
-    "ds_segments": "metabolomics/tmp/ds_segments",
-    "fdr_rankings": "metabolomics/tmp/fdr",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.000693,
@@ -15,8 +13,6 @@
     "formulas_chunks": "metabolomics/db/formulas_chunks",
     "formula_to_id_chunks": "metabolomics/db/formula_to_id",
     "centroids_chunks": "metabolomics/db/centroids_chunks",
-    "clipped_centroids_chunks": "metabolomics/tmp/clipped_centroids_chunks",
-    "centroids_segments": "metabolomics/tmp/centroids_segments",
     "databases": [
       "metabolomics/db/mol_db1.pickle",
       "metabolomics/db/mol_db2.pickle"

--- a/metabolomics/input_config_small.json
+++ b/metabolomics/input_config_small.json
@@ -3,7 +3,6 @@
     "name": "Brain02_Bregma1-42_02",
     "imzml_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.imzML",
     "ibd_path": "https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.ibd",
-    "ds_imzml_reader": "metabolomics/tmp/imzml_reader/Brain02_Bregma1-42_02.pickle",
     "num_decoys": 20,
     "polarity": "+",
     "isocalc_sigma": 0.000693,

--- a/pywren-annotation-pipeline-demo.ipynb
+++ b/pywren-annotation-pipeline-demo.ipynb
@@ -524,9 +524,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.utils import clean_from_cos\n",
-    "clean_from_cos(config, config[\"storage\"][\"ds_bucket\"], \"metabolomics/tmp\")\n",
-    "clean_from_cos(config, config[\"storage\"][\"db_bucket\"], \"metabolomics/tmp\")"
+    "pipeline.clean()"
    ]
   }
  ],

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ setup(name='pywren-annotation-pipeline',
       url='https://github.com/metaspace2020/pywren-annotation-pipeline',
       packages=find_packages(),
       install_requires=[
-          "pywren-ibm-cloud>=1.5.0",
+          "pywren-ibm-cloud>=1.5.2",
           # pandas version should match the version in the runtime to ensure data generated locally can be unpickled
           # in pywren actions
           "pandas==0.25.1",


### PR DESCRIPTION
I changed the whole pipeline to create and manage cloud objects without the necessity of keys prefixes at all.

**main changes:**
- update the project for recent PyWren changes (for the next PyWren version 1.5.2).
- add support in cloud objects for the whole pipeline.
- add cache cloud objects mechanism - to make the pipeline easy to be developed and more stable. the cache mechanism stores and manages cobjects - if a single stage failed for some reason, we dont have to restart everything from the beginning, the pipeline will load the required data from cache and will continue to run from the same point automatically.
- add cloud objects cleansing by `pipeline.clean()`. this method will also delete cached data.

**changes for the next PR:**
- add support in cloud objects for the database builder
- add support in cache from the database builder
- recover `read_object_with_retry()` instead of `storage.get_cobject()`