### PR TITLE
Improve Pipeline cache

### DIFF
--- a/annotation_pipeline/cache.py
+++ b/annotation_pipeline/cache.py
@@ -1,0 +1,51 @@
+import pickle
+from pywren_ibm_cloud.storage.utils import CloudObject
+
+from annotation_pipeline.utils import get_ibm_cos_client, list_keys, clean_from_cos
+
+
+class PipelineCacher:
+    def __init__(self, pw, dataset_name):
+        self.pywren_executor = pw
+        self.config = self.pywren_executor.config
+
+        self.storage_handler = get_ibm_cos_client(self.config)
+        self.bucket = self.config['pywren']['storage_bucket']
+        self.prefix = f'metabolomics/cache/{dataset_name}'
+
+    def load(self, key):
+        data_stream = self.storage_handler.get_object(Bucket=self.bucket, Key=key)['Body']
+        return pickle.loads(data_stream.read())
+
+    def save(self, data, key):
+        p = pickle.dumps(data)
+        self.storage_handler.put_object(Bucket=self.bucket, Key=key, Body=p)
+
+    def exists(self, key):
+        try:
+            self.storage_handler.head_object(Bucket=self.bucket, Key=key)
+            return True
+        except Exception:
+            return False
+
+    def clean(self):
+        keys = list_keys(self.bucket, self.prefix, self.storage_handler)
+
+        cobjects_to_clean = []
+        for cache_key in keys:
+            cache_data = self.load(cache_key)
+            if isinstance(cache_data, tuple):
+                for obj in cache_data:
+                    if isinstance(obj, list):
+                        if isinstance(obj[0], CloudObject):
+                            cobjects_to_clean.extend(obj)
+                    elif isinstance(obj, CloudObject):
+                        cobjects_to_clean.append(obj)
+            elif isinstance(cache_data, list):
+                if isinstance(cache_data[0], CloudObject):
+                    cobjects_to_clean.extend(cache_data)
+            elif isinstance(cache_data, CloudObject):
+                cobjects_to_clean.append(cache_data)
+
+        self.pywren_executor.clean(cs=cobjects_to_clean)
+        clean_from_cos(self.config, self.bucket, self.prefix, self.storage_handler)

--- a/annotation_pipeline/utils.py
+++ b/annotation_pipeline/utils.py
@@ -1,6 +1,5 @@
 import logging
 from concurrent.futures.thread import ThreadPoolExecutor
-from pywren_ibm_cloud.storage.utils import CloudObject
 from pathlib import Path
 from datetime import datetime
 import numpy as np
@@ -8,8 +7,6 @@ import ibm_boto3
 import ibm_botocore
 import pandas as pd
 import csv
-import pickle
-import json
 
 import requests
 
@@ -201,60 +198,3 @@ def read_ranges_from_url(url, ranges):
 
     return [request_results[request_i][request_lo:request_hi]
             for input_i, request_i, request_lo, request_hi in sorted(tasks)]
-
-
-def cache_exists(key):
-    config = json.load(open('config.json', 'r'))
-    ibm_cos = get_ibm_cos_client(config)
-    cache_bucket = config['pywren']['storage_bucket']
-    try:
-        ibm_cos.head_object(Bucket=cache_bucket, Key=key)
-        return True
-    except Exception:
-        return False
-
-
-def load_from_cache(key):
-    config = json.load(open('config.json', 'r'))
-    ibm_cos = get_ibm_cos_client(config)
-    cache_bucket = config['pywren']['storage_bucket']
-    return pickle.loads(ibm_cos.get_object(Bucket=cache_bucket, Key=key)['Body'].read())
-
-
-def get_cached_cobjects(prefix):
-    config = json.load(open('config.json', 'r'))
-    ibm_cos = get_ibm_cos_client(config)
-    cache_bucket = config['pywren']['storage_bucket']
-    keys = list_keys(cache_bucket, prefix, ibm_cos)
-
-    cached_cobjects = []
-    for cache_key in keys:
-        cache_data = load_from_cache(cache_key)
-        if isinstance(cache_data, tuple):
-            for obj in cache_data:
-                if isinstance(obj, list):
-                    if isinstance(obj[0], CloudObject):
-                        cached_cobjects.extend(obj)
-                elif isinstance(obj, CloudObject):
-                    cached_cobjects.append(obj)
-        elif isinstance(cache_data, list):
-            if isinstance(cache_data[0], CloudObject):
-                cached_cobjects.extend(cache_data)
-        elif isinstance(cache_data, CloudObject):
-            cached_cobjects.append(cache_data)
-
-    return cached_cobjects
-
-
-def save_to_cache(data, key):
-    config = json.load(open('config.json', 'r'))
-    ibm_cos = get_ibm_cos_client(config)
-    cache_bucket = config['pywren']['storage_bucket']
-    ibm_cos.put_object(Bucket=cache_bucket, Key=key, Body=pickle.dumps(data))
-
-
-def clean_cache(prefix):
-    config = json.load(open('config.json', 'r'))
-    ibm_cos = get_ibm_cos_client(config)
-    cache_bucket = config['pywren']['storage_bucket']
-    clean_from_cos(config, cache_bucket, prefix, ibm_cos)

--- a/scripts/run_pipeline.py
+++ b/scripts/run_pipeline.py
@@ -12,6 +12,9 @@ if __name__ == '__main__':
     parser.add_argument('--config', type=argparse.FileType('r'), default='config.json', help='config.json path')
     parser.add_argument('--input', type=argparse.FileType('r'), default='input_config.json',
                         help='input_config.json path')
+    parser.add_argument('--no-cache', dest='use_cache', action='store_false',
+                        help='disable loading and saving cached cloud objects')
+    parser.set_defaults(use_cache=True)
     args = parser.parse_args()
 
     start = time.time()
@@ -19,7 +22,7 @@ if __name__ == '__main__':
     config = json.load(args.config)
     input_config = json.load(args.input)
 
-    pipeline = Pipeline(config, input_config)
+    pipeline = Pipeline(config, input_config, use_cache=args.use_cache)
     pipeline()
     results_df = pipeline.get_results()
 


### PR DESCRIPTION
**main changes:**
- add `use_cache` flag for `Pipeline` class.
- add `--no-cache` option parameter for `run_pipeline.py` script.
- move cache from local to ibm cos - this will be useful when the pipeline's steps don't run on the same local machine.
- add dedicated class for cache `PipelineCacher` and organise its all operations.