### PR TITLE
Optimizations & integration of alternate algorithms into pipeline

### DIFF
--- a/annotation_pipeline/__main__.py
+++ b/annotation_pipeline/__main__.py
@@ -8,7 +8,7 @@ import matplotlib.pyplot as plt
 from annotation_pipeline.utils import get_ibm_cos_client
 from annotation_pipeline.imzml import convert_imzml_to_txt
 from annotation_pipeline.pipeline import Pipeline
-from annotation_pipeline.molecular_db import build_database, calculate_centroids, upload_mol_dbs_from_dir
+from annotation_pipeline.molecular_db import upload_mol_dbs_from_dir
 
 logger = logging.getLogger(name='annotation_pipeline')
 
@@ -41,12 +41,9 @@ def generate_centroids(args, config):
     databases_path = Path(Path(input_db['databases'][0]).parent)
     upload_mol_dbs_from_dir(config, config['storage']['db_bucket'], databases_path, databases_path)
 
-    build_database(config, input_db)
-    # Use '+' if missing from the config, but it's better to get the actual value as it affects the results
-    polarity = input_ds['polarity']
-    # Use 0.001238 if missing from the config, but it's better to get the actual value as it affects the results
-    isocalc_sigma = input_ds['isocalc_sigma']
-    calculate_centroids(config, input_db, polarity, isocalc_sigma)
+    pipeline = Pipeline(config, input_ds, input_db)
+    pipeline.build_database()
+    pipeline.calculate_centroids()
 
 
 def convert_imzml(args, config):

--- a/annotation_pipeline/cache.py
+++ b/annotation_pipeline/cache.py
@@ -13,9 +13,9 @@ class PipelineCacher:
         self.bucket = self.config['pywren']['storage_bucket']
         self.prefixes = {
             '': 'metabolomics/cache/',
-            ':ds/': f'metabolomics/cache/{ds_name}/',
-            ':db/': f'metabolomics/cache/{db_name}/',
-            ':ds/:db/': f'metabolomics/cache/{ds_name}/{db_name}/',
+            ':ds': f'metabolomics/cache/{ds_name}/',
+            ':db': f'metabolomics/cache/{db_name}/',
+            ':ds/:db': f'metabolomics/cache/{ds_name}/{db_name}/',
         }
 
     def resolve_key(self, key):

--- a/annotation_pipeline/cache.py
+++ b/annotation_pipeline/cache.py
@@ -5,17 +5,17 @@ from annotation_pipeline.utils import get_ibm_cos_client, list_keys, clean_from_
 
 
 class PipelineCacher:
-    def __init__(self, pw, ds_name, db_name):
+    def __init__(self, pw, namespace, ds_name, db_name):
         self.pywren_executor = pw
         self.config = self.pywren_executor.config
 
         self.storage_handler = get_ibm_cos_client(self.config)
         self.bucket = self.config['pywren']['storage_bucket']
         self.prefixes = {
-            '': 'metabolomics/cache/',
-            ':ds': f'metabolomics/cache/{ds_name}/',
-            ':db': f'metabolomics/cache/{db_name}/',
-            ':ds/:db': f'metabolomics/cache/{ds_name}/{db_name}/',
+            '': f'metabolomics/cache/{namespace}',
+            ':ds': f'metabolomics/cache/{namespace}/{ds_name}/',
+            ':db': f'metabolomics/cache/{namespace}/{db_name}/',
+            ':ds/:db': f'metabolomics/cache/{namespace}/{ds_name}/{db_name}/',
         }
 
     def resolve_key(self, key):

--- a/annotation_pipeline/cache.py
+++ b/annotation_pipeline/cache.py
@@ -5,36 +5,52 @@ from annotation_pipeline.utils import get_ibm_cos_client, list_keys, clean_from_
 
 
 class PipelineCacher:
-    def __init__(self, pw, dataset_name):
+    def __init__(self, pw, ds_name, db_name):
         self.pywren_executor = pw
         self.config = self.pywren_executor.config
 
         self.storage_handler = get_ibm_cos_client(self.config)
         self.bucket = self.config['pywren']['storage_bucket']
-        self.prefix = f'metabolomics/cache/{dataset_name}/'
+        self.prefixes = {
+            '': 'metabolomics/cache/',
+            ':ds/': f'metabolomics/cache/{ds_name}/',
+            ':db/': f'metabolomics/cache/{db_name}/',
+            ':ds/:db/': f'metabolomics/cache/{ds_name}/{db_name}/',
+        }
+
+    def resolve_key(self, key):
+        parts = key.rsplit('/', maxsplit=1)
+        if len(parts) == 1:
+            return self.prefixes[''] + parts[0]
+        else:
+            prefix, suffix = parts
+            return self.prefixes[prefix] + suffix
 
     def load(self, key):
-        data_stream = self.storage_handler.get_object(Bucket=self.bucket, Key=self.prefix + key)['Body']
+        data_stream = self.storage_handler.get_object(Bucket=self.bucket, Key=self.resolve_key(key))['Body']
         return pickle.loads(data_stream.read())
 
     def save(self, data, key):
         p = pickle.dumps(data)
-        self.storage_handler.put_object(Bucket=self.bucket, Key=self.prefix + key, Body=p)
+        self.storage_handler.put_object(Bucket=self.bucket, Key=self.resolve_key(key), Body=p)
 
     def exists(self, key):
         try:
-            self.storage_handler.head_object(Bucket=self.bucket, Key=self.prefix + key)
+            self.storage_handler.head_object(Bucket=self.bucket, Key=self.resolve_key(key))
             return True
         except Exception:
             return False
 
     def clean(self):
-        keys = list_keys(self.bucket, self.prefix, self.storage_handler)
-        unprefixed_keys = [key[len(self.prefix):] for key in keys]
+        keys = [key
+                for prefix in self.prefixes.values()
+                for key in list_keys(self.bucket, prefix, self.storage_handler)]
 
         cobjects_to_clean = []
-        for cache_key in unprefixed_keys:
-            cache_data = self.load(cache_key)
+        for cache_key in keys:
+            data_stream = self.storage_handler.get_object(Bucket=self.bucket, Key=cache_key)['Body']
+            cache_data = pickle.loads(data_stream.read())
+
             if isinstance(cache_data, tuple):
                 for obj in cache_data:
                     if isinstance(obj, list):
@@ -49,4 +65,5 @@ class PipelineCacher:
                 cobjects_to_clean.append(cache_data)
 
         self.pywren_executor.clean(cs=cobjects_to_clean)
-        clean_from_cos(self.config, self.bucket, self.prefix, self.storage_handler)
+        for prefix in self.prefixes.values():
+            clean_from_cos(self.config, self.bucket, prefix, self.storage_handler)

--- a/annotation_pipeline/fdr.py
+++ b/annotation_pipeline/fdr.py
@@ -20,7 +20,7 @@ def msgpack_load_text(stream):
     return msgpack.load(stream, encoding='utf-8')
 
 
-def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
+def build_fdr_rankings(pw, bucket, input_data, input_db, formula_to_id_cobjects, formula_scores_df):
 
     def build_ranking(group_i, ranking_i, database, modifier, adduct, id, storage):
         print("Building ranking...")
@@ -42,9 +42,8 @@ def build_fdr_rankings(pw, bucket, input_data, input_db, formula_scores_df):
             mol_formulas = list(map(safe_generate_ion_formula, mols, repeat(modifier), adducts))
 
         formula_to_id = {}
-        keys = list_keys(bucket, f'{input_db["formula_to_id_chunks"]}/', storage)
-        for key in keys:
-            formula_to_id_chunk = read_object_with_retry(storage, bucket, key, msgpack_load_text)
+        for cobject in formula_to_id_cobjects:
+            formula_to_id_chunk = read_cloud_object_with_retry(storage, cobject, msgpack_load_text)
 
             for formula in mol_formulas:
                 if formula_to_id_chunk.get(formula) is not None:

--- a/annotation_pipeline/formula_parser.py
+++ b/annotation_pipeline/formula_parser.py
@@ -16,6 +16,10 @@ def parse_formula(f):
             for (elem, n) in formula_regexp.findall(f)]
 
 
+def format_modifiers(*adducts):
+    return ''.join(adduct for adduct in adducts if adduct and adduct not in ('[M]+', '[M]-'))
+
+
 def generate_ion_formula(formula, *adducts):
     formula = clean_regexp.sub('', formula)
     adducts = [clean_regexp.sub('', adduct) for adduct in adducts]

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -159,8 +159,6 @@ def read_ds_segments(ds_segms_cobjects, ds_segms_len, pw_mem_mb, ds_segm_size_mb
             sp_df = list(pool.map(lambda co: read_ds_segment(co, vm_algorithm, storage), ds_segms_cobjects))
         sp_df = pd.concat(sp_df, ignore_index=True, sort=False)
 
-    sp_df.sort_values('mz', inplace=True)
-
     return sp_df
 
 

--- a/annotation_pipeline/image.py
+++ b/annotation_pipeline/image.py
@@ -7,7 +7,7 @@ import msgpack_numpy as msgpack
 
 from annotation_pipeline.utils import ds_dims, get_pixel_indices, read_cloud_object_with_retry
 from annotation_pipeline.validate import make_compute_image_metrics, formula_image_metrics
-from annotation_pipeline.segment import ISOTOPIC_PEAK_N
+ISOTOPIC_PEAK_N = 4
 
 
 class ImagesManager:

--- a/annotation_pipeline/metaspace_fdr.py
+++ b/annotation_pipeline/metaspace_fdr.py
@@ -1,0 +1,237 @@
+# This file was copied directly from METASPACE to minimize divergence between the two implementations
+#
+# Some concepts don't match directly:
+# In METASPACE a "modifier" is a concatenation of chem_mod, neutral_loss and adduct
+# In pywren-annotation-pipeline a modifier is just a neutral_loss. It does not include an adduct.
+#
+# In METASPACE the "neutral_losses" list is expected to not include the empty value ''
+# In pywren-annotation-pipeline the modifiers list includes '', so it has to be removed before this is called
+#
+# FDR.estimate_fdr expects formula_msm to have `formula` and `adduct` columns,
+# but pywren-annotation-pipeline doesn't normally carry these through the whole pipeline
+
+import logging
+from itertools import product
+
+import numpy as np
+import pandas as pd
+
+from annotation_pipeline.formula_parser import format_modifiers
+
+logger = logging.getLogger('engine')
+
+DECOY_ADDUCTS = [
+    '+He',
+    '+Li',
+    '+Be',
+    '+B',
+    '+C',
+    '+N',
+    '+O',
+    '+F',
+    '+Ne',
+    '+Mg',
+    '+Al',
+    '+Si',
+    '+P',
+    '+S',
+    '+Cl',
+    '+Ar',
+    '+Ca',
+    '+Sc',
+    '+Ti',
+    '+V',
+    '+Cr',
+    '+Mn',
+    '+Fe',
+    '+Co',
+    '+Ni',
+    '+Cu',
+    '+Zn',
+    '+Ga',
+    '+Ge',
+    '+As',
+    '+Se',
+    '+Br',
+    '+Kr',
+    '+Rb',
+    '+Sr',
+    '+Y',
+    '+Zr',
+    '+Nb',
+    '+Mo',
+    '+Ru',
+    '+Rh',
+    '+Pd',
+    '+Ag',
+    '+Cd',
+    '+In',
+    '+Sn',
+    '+Sb',
+    '+Te',
+    '+I',
+    '+Xe',
+    '+Cs',
+    '+Ba',
+    '+La',
+    '+Ce',
+    '+Pr',
+    '+Nd',
+    '+Sm',
+    '+Eu',
+    '+Gd',
+    '+Tb',
+    '+Dy',
+    '+Ho',
+    '+Ir',
+    '+Th',
+    '+Pt',
+    '+Os',
+    '+Yb',
+    '+Lu',
+    '+Bi',
+    '+Pb',
+    '+Re',
+    '+Tl',
+    '+Tm',
+    '+U',
+    '+W',
+    '+Au',
+    '+Er',
+    '+Hf',
+    '+Hg',
+    '+Ta',
+]
+
+
+def _make_target_modifiers_df(chem_mods, neutral_losses, target_adducts):
+    """
+    All combinations of chemical modification, neutral loss or target adduct.
+    Note that the combination order matters as these target modifiers are used later
+    to map back to separated chemical modification, neutral loss and target adduct fields.
+    """
+    rows = [
+        (cm, nl, ta, format_modifiers(cm, nl, ta), format_modifiers(cm, nl))
+        for cm, nl, ta in product(['', *chem_mods], ['', *neutral_losses], target_adducts)
+    ]
+    df = pd.DataFrame(
+        rows,
+        columns=['chem_mod', 'neutral_loss', 'adduct', 'target_modifier', 'decoy_modifier_prefix'],
+        dtype='O',
+    )
+    df = df.set_index('target_modifier')
+    return df
+
+
+class FDR:
+    fdr_levels = [0.05, 0.1, 0.2, 0.5]
+
+    def __init__(self, fdr_config, chem_mods, neutral_losses, target_adducts, analysis_version):
+        self.decoy_sample_size = fdr_config['decoy_sample_size']
+        self.chem_mods = chem_mods
+        self.neutral_losses = neutral_losses
+        self.target_adducts = target_adducts
+        self.analysis_version = analysis_version
+        self.td_df = None
+        self.random_seed = 42
+        self.target_modifiers_df = _make_target_modifiers_df(
+            chem_mods, neutral_losses, target_adducts
+        )
+
+    def _choose_decoys(self, decoys):
+        copy = decoys.copy()
+        np.random.shuffle(copy)
+        return copy[: self.decoy_sample_size]
+
+    def _decoy_adduct_gen(self, target_formulas, decoy_adducts_cand):
+        np.random.seed(self.random_seed)
+        target_modifiers = list(self.target_modifiers_df.decoy_modifier_prefix.items())
+        # pylint: disable=invalid-name
+        for formula, (tm, dm_prefix) in product(target_formulas, target_modifiers):
+            for da in self._choose_decoys(decoy_adducts_cand):
+                yield (formula, tm, dm_prefix + da)
+
+    def decoy_adducts_selection(self, target_formulas):
+        decoy_adduct_cand = [add for add in DECOY_ADDUCTS if add not in self.target_adducts]
+        self.td_df = pd.DataFrame(
+            self._decoy_adduct_gen(target_formulas, decoy_adduct_cand),
+            columns=['formula', 'tm', 'dm'],
+        )
+
+    def ion_tuples(self):
+        """Returns list of tuples in List[(formula, modifier)] form.
+
+        All ions needed for FDR calculation as a list of (formula, modifier),
+        where modifier is a combination of chemical modification, neutral loss and adduct
+        """
+        d_ions = self.td_df[['formula', 'dm']].drop_duplicates().values.tolist()
+        t_ions = self.td_df[['formula', 'tm']].drop_duplicates().values.tolist()
+        return list(map(tuple, t_ions + d_ions))
+
+    def target_modifiers(self):
+        """ List of possible modifier values for target ions """
+        return self.target_modifiers_df.index.tolist()
+
+    @classmethod
+    def nearest_fdr_level(cls, fdr):
+        for level in cls.fdr_levels:
+            if round(fdr, 2) <= level:
+                return level
+        return 1.0
+
+    @staticmethod
+    def _msm_fdr_map(target_msm, decoy_msm):
+        target_msm_hits = pd.Series(target_msm.msm.value_counts(), name='target')
+        decoy_msm_hits = pd.Series(decoy_msm.msm.value_counts(), name='decoy')
+        msm_df = (
+            pd.concat([target_msm_hits, decoy_msm_hits], axis=1)
+            .fillna(0)
+            .sort_index(ascending=False)
+        )
+        msm_df['target_cum'] = msm_df.target.cumsum()
+        msm_df['decoy_cum'] = msm_df.decoy.cumsum()
+        msm_df['fdr'] = msm_df.decoy_cum / msm_df.target_cum
+        return msm_df.fdr
+
+    def _digitize_fdr(self, fdr_df):
+        if self.analysis_version < 2:
+            df = fdr_df.copy().sort_values(by='msm', ascending=False)
+            msm_levels = [df[df.fdr < fdr_thr].msm.min() for fdr_thr in self.fdr_levels]
+            df['fdr_d'] = 1.0
+            for msm_thr, fdr_thr in zip(msm_levels, self.fdr_levels):
+                row_mask = np.isclose(df.fdr_d, 1.0) & np.greater_equal(df.msm, msm_thr)
+                df.loc[row_mask, 'fdr_d'] = fdr_thr
+            df['fdr'] = df.fdr_d
+            return df.drop('fdr_d', axis=1)
+
+        df = fdr_df.sort_values(by='msm')
+        df['fdr'] = np.minimum.accumulate(df.fdr)  # pylint: disable=no-member
+        return df
+
+    def estimate_fdr(self, formula_msm):
+        logger.info('Estimating FDR')
+
+        td_df = self.td_df.set_index('tm')
+
+        target_fdr_df_list = []
+        for tm in self.target_modifiers_df.index.drop_duplicates():  # pylint: disable=invalid-name
+            target_msm = formula_msm[formula_msm.modifier == tm]
+            full_decoy_df = td_df.loc[tm, ['formula', 'dm']]
+
+            msm_fdr_list = []
+            for i in range(self.decoy_sample_size):
+                decoy_subset_df = full_decoy_df[i :: self.decoy_sample_size]
+                decoy_msm = pd.merge(
+                    formula_msm,
+                    decoy_subset_df,
+                    left_on=['formula', 'modifier'],
+                    right_on=['formula', 'dm'],
+                )
+                msm_fdr = self._msm_fdr_map(target_msm, decoy_msm)
+                msm_fdr_list.append(msm_fdr)
+
+            msm_fdr_avg = pd.Series(pd.concat(msm_fdr_list, axis=1).median(axis=1), name='fdr')
+            target_fdr = self._digitize_fdr(target_msm.join(msm_fdr_avg, on='msm'))
+            target_fdr_df_list.append(target_fdr.drop('msm', axis=1))
+
+        return pd.concat(target_fdr_df_list, axis=0)

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -17,12 +17,11 @@ N_FORMULAS_SEGMENTS = 256
 N_HASH_CHUNKS = 32  # should be less than N_FORMULAS_SEGMENTS
 
 
-def build_database(pw, config, input_db):
-    bucket = config["storage"]["db_bucket"]
+def build_database(pw, db_bucket, db_config):
 
-    adducts = [*input_db['adducts'], *DECOY_ADDUCTS]
-    modifiers = input_db['modifiers']
-    databases = input_db['databases']
+    adducts = [*db_config['adducts'], *DECOY_ADDUCTS]
+    modifiers = db_config['modifiers']
+    databases = db_config['databases']
 
     def hash_formula_to_chunk(formula):
         m = hashlib.md5()
@@ -33,7 +32,7 @@ def build_database(pw, config, input_db):
         print(f'Generating formulas for adduct {adduct}')
 
         def _get_mols(mols_key):
-            return pickle.loads(read_object_with_retry(storage, bucket, mols_key))
+            return pickle.loads(read_object_with_retry(storage, db_bucket, mols_key))
 
         with ThreadPoolExecutor(max_workers=128) as pool:
             mols_list = list(pool.map(_get_mols, databases))

--- a/annotation_pipeline/molecular_db.py
+++ b/annotation_pipeline/molecular_db.py
@@ -264,3 +264,68 @@ def validate_formula_cobjects(storage, formula_cobjects):
 
     # __import__('__main__').db_segms = db_segms
 
+
+def validate_peaks_cobjects(pw, peaks_cobjects):
+    def get_segm_stats(storage, segm_cobject):
+        segm = pd.read_msgpack(storage.get_cobject(segm_cobject))
+        n_peaks = segm.groupby(level='formula_i').peak_i.count()
+        formula_is = segm.index.unique()
+        stats = pd.Series({
+            'min_mz': segm.mz.min(),
+            'max_mz': segm.mz.max(),
+            'min_formula_i': segm.index.min(),
+            'max_formula_i': segm.index.max(),
+            'avg_n_peaks': n_peaks.mean(),
+            'min_n_peaks': n_peaks.min(),
+            'max_n_peaks': n_peaks.max(),
+            'max_int': segm.int.max(),
+            'missing_peaks': (
+                segm.loc[n_peaks.index[n_peaks != 4]]
+                .groupby(level='formula_i')
+                .peak_i
+                .apply(lambda peak_is: len(set(range(len(peak_is))) - set(peak_is)))
+                .sum()
+            ),
+            'n_formulas': len(formula_is),
+            'n_peaks': len(segm),
+        })
+        return formula_is, stats
+
+    futures = pw.map(get_segm_stats, peaks_cobjects, runtime_memory=1024)
+    results = pw.get_result(futures)
+    segm_formula_is = [formula_is for formula_is, stats in results]
+    stats_df = pd.DataFrame([stats for formula_is, stats in results])
+
+    try:
+        __import__('__main__').peaks_cobjects = stats_df
+        logger.info('validate_peaks_cobjects debug info written to "peaks_cobjects" variable')
+    except:
+        pass
+
+    with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
+        # Report cases with fewer peaks than expected (indication that formulas are being split between multiple segments)
+        wrong_n_peaks = stats_df[(stats_df.avg_n_peaks < 3.9) | (stats_df.min_n_peaks < 2) | (stats_df.max_n_peaks > 4)]
+        if not wrong_n_peaks.empty:
+            logger.warning('segment_centroids produced segments with unexpected peaks-per-formula (should be almost always 4, occasionally 2 or 3):')
+            logger.warning(wrong_n_peaks)
+
+        # Report missing peaks
+        missing_peaks = stats_df[stats_df.missing_peaks > 0]
+        if not missing_peaks.empty:
+            logger.warning('segment_centroids produced segments with missing peaks:')
+            logger.warning(missing_peaks)
+
+    formula_in_segms_df = pd.DataFrame([
+        (formula_i, segm_i) for segm_i, formula_is in enumerate(segm_formula_is)
+        for formula_i in formula_is
+    ], columns=['formula_i','segm_i'])
+    formulas_in_multiple_segms = (formula_in_segms_df.groupby('formula_i').segm_i.count() > 1)[lambda s: s].index
+    formulas_in_multiple_segms_df = formula_in_segms_df[lambda df: df.formula_i.isin(formulas_in_multiple_segms)].sort_values('formula_i')
+
+    n_per_segm = formula_in_segms_df.groupby('segm_i').formula_i.count()
+    if not formulas_in_multiple_segms_df.empty:
+        logger.warning('segment_centroids produced put the same formula in multiple segments:')
+        logger.warning(formulas_in_multiple_segms_df)
+
+    print(f'Found {stats_df.n_peaks.sum()} peaks for {stats_df.n_formulas.sum()} formulas across {len(peaks_cobjects)} segms')
+    print(f'Segm sizes range from {n_per_segm.min()} to {n_per_segm.max()}')

--- a/annotation_pipeline/molecular_db_local.py
+++ b/annotation_pipeline/molecular_db_local.py
@@ -1,12 +1,12 @@
-from itertools import repeat, product
+from functools import partial
 from concurrent.futures import ThreadPoolExecutor, ProcessPoolExecutor
-import msgpack_numpy as msgpack
 import pandas as pd
 import pickle
 import math
 
 from annotation_pipeline.formula_parser import safe_generate_ion_formula
-from annotation_pipeline.utils import logger, clean_from_cos, read_object_with_retry
+from annotation_pipeline.metaspace_fdr import FDR
+from annotation_pipeline.utils import logger, read_object_with_retry
 
 
 DECOY_ADDUCTS = ['+He', '+Li', '+Be', '+B', '+C', '+N', '+O', '+F', '+Ne', '+Mg', '+Al', '+Si', '+P', '+S', '+Cl', '+Ar', '+Ca', '+Sc', '+Ti', '+V', '+Cr', '+Mn', '+Fe', '+Co', '+Ni', '+Cu', '+Zn', '+Ga', '+Ge', '+As', '+Se', '+Br', '+Kr', '+Rb', '+Sr', '+Y', '+Zr', '+Nb', '+Mo', '+Ru', '+Rh', '+Pd', '+Ag', '+Cd', '+In', '+Sn', '+Sb', '+Te', '+I', '+Xe', '+Cs', '+Ba', '+La', '+Ce', '+Pr', '+Nd', '+Sm', '+Eu', '+Gd', '+Tb', '+Dy', '+Ho', '+Ir', '+Th', '+Pt', '+Os', '+Yb', '+Lu', '+Bi', '+Pb', '+Re', '+Tl', '+Tm', '+U', '+W', '+Au', '+Er', '+Hf', '+Hg', '+Ta']
@@ -14,28 +14,32 @@ N_FORMULAS_SEGMENTS = 256
 FORMULA_TO_ID_CHUNK_MB = 512
 
 
-def build_database_local(storage, db_bucket, db_config):
-
-    formulas_df = get_formulas_df(storage, db_bucket, db_config)
+def build_database_local(storage, db_bucket, db_config, ds_config):
+    db_data_cobjects, formulas_df = get_formulas_df(storage, db_bucket, db_config, ds_config)
     num_formulas = len(formulas_df)
     logger.info(f'Generated {num_formulas} formulas')
 
     db_segm_cobjects = store_formula_segments(storage, formulas_df)
     logger.info(f'Stored {num_formulas} formulas in {len(db_segm_cobjects)} chunks')
 
-    formula_to_id_cobjects = store_formula_to_id(storage, formulas_df)
-    logger.info(f'Built {len(formula_to_id_cobjects)} formula_to_id dictionaries chunks')
-
-    return db_segm_cobjects, formula_to_id_cobjects
+    return db_segm_cobjects, db_data_cobjects
 
 
-def _generate_formulas(args):
-    mols, modifier, adduct = args
-    return list(map(safe_generate_ion_formula, mols, repeat(modifier), repeat(adduct)))
+def _get_db_fdr_and_formulas(ds_config, modifiers, adducts, mols):
+    fdr_config = {'decoy_sample_size': ds_config['num_decoys']}
+    nonempty_modifiers = [m for m in modifiers if m]
+    fdr = FDR(fdr_config, [], nonempty_modifiers, adducts, 2)
+    fdr.decoy_adducts_selection(mols)
+    formulas = [
+        (formula, modifier, safe_generate_ion_formula(formula, modifier))
+        for formula, modifier in fdr.ion_tuples()
+    ]
+    formula_map_df = pd.DataFrame(formulas, columns=['formula', 'modifier', 'ion_formula'])
+    return fdr, formula_map_df
 
 
-def get_formulas_df(storage, db_bucket, input_db):
-    adducts = [*input_db['adducts'], *DECOY_ADDUCTS]
+def get_formulas_df(storage, db_bucket, input_db, ds_config):
+    adducts = input_db['adducts']
     modifiers = input_db['modifiers']
     databases = input_db['databases']
 
@@ -47,20 +51,36 @@ def get_formulas_df(storage, db_bucket, input_db):
         dbs = list(pool.map(_get_mols, databases))
 
     # Calculate formulas
-    formulas = set()
+    db_datas = []
+    ion_formula = set()
     with ProcessPoolExecutor() as ex:
-        for chunk in ex.map(_generate_formulas, product(dbs, modifiers, adducts)):
-            formulas.update(chunk)
+        func = partial(_get_db_fdr_and_formulas, ds_config, modifiers, adducts)
+        for db, (fdr, formula_map_df) in zip(databases, ex.map(func, dbs)):
+            db_datas.append((db, fdr, formula_map_df))
+            ion_formula.update(formula_map_df.ion_formula)
 
-    if None in formulas:
-        formulas.remove(None)
+    if None in ion_formula:
+        ion_formula.remove(None)
 
-    return pd.DataFrame({'formula': sorted(formulas)}).rename_axis(index='formula_i')
+    formulas_df = pd.DataFrame({'ion_formula': sorted(ion_formula)}).rename_axis(index='formula_i')
+    formula_to_id = pd.Series(formulas_df.index, formulas_df.ion_formula)
+    for db, fdr, formula_map_df in db_datas:
+        formula_map_df['formula_i'] = formula_to_id[formula_map_df.ion_formula].values
+        del formula_map_df['ion_formula']
+
+    def _store_db_data(db_data):
+        return storage.put_cobject(pickle.dumps(db_data))
+
+    with ThreadPoolExecutor() as pool:
+        db_data_cobjects = list(pool.map(_store_db_data, db_datas))
+
+    return db_data_cobjects, formulas_df
 
 
 def store_formula_segments(storage, formulas_df):
-    subsegm_size = math.ceil(len(formulas_df) / N_FORMULAS_SEGMENTS)
-    segm_list = [formulas_df[i:i+subsegm_size] for i in range(0, len(formulas_df), subsegm_size)]
+    segm_bounds = [len(formulas_df) * i // N_FORMULAS_SEGMENTS for i in range(N_FORMULAS_SEGMENTS+1)]
+    segm_ranges = list(zip(segm_bounds[:-1], segm_bounds[1:]))
+    segm_list = [formulas_df.ion_formula.iloc[start:end] for start, end in segm_ranges]
 
     def _store(segm):
         return storage.put_cobject(segm.to_msgpack())
@@ -69,17 +89,3 @@ def store_formula_segments(storage, formulas_df):
         return list(pool.map(_store, segm_list))
 
 
-def store_formula_to_id(storage, formulas_df):
-    num_formulas = len(formulas_df)
-    n_formula_to_id = int(math.ceil(num_formulas * 200 / (FORMULA_TO_ID_CHUNK_MB * 1024 ** 2)))
-    formula_to_id_cobjects = []
-    for ch_i in range(n_formula_to_id):
-        print(f'Storing formula_to_id dictionary chunk {ch_i}')
-        start_idx = num_formulas * ch_i // n_formula_to_id
-        end_idx = num_formulas * (ch_i + 1) // n_formula_to_id
-
-        formula_to_id = formulas_df.iloc[start_idx:end_idx].formula.to_dict()
-
-        formula_to_id_cobjects.append(storage.put_cobject(msgpack.dumps(formula_to_id)))
-
-    return formula_to_id_cobjects

--- a/annotation_pipeline/molecular_db_local.py
+++ b/annotation_pipeline/molecular_db_local.py
@@ -19,10 +19,10 @@ def build_database_local(storage, db_bucket, db_config, ds_config):
     num_formulas = len(formulas_df)
     logger.info(f'Generated {num_formulas} formulas')
 
-    db_segm_cobjects = store_formula_segments(storage, formulas_df)
-    logger.info(f'Stored {num_formulas} formulas in {len(db_segm_cobjects)} chunks')
+    formula_cobjects = store_formula_segments(storage, formulas_df)
+    logger.info(f'Stored {num_formulas} formulas in {len(formula_cobjects)} chunks')
 
-    return db_segm_cobjects, db_data_cobjects
+    return formula_cobjects, db_data_cobjects
 
 
 def _get_db_fdr_and_formulas(ds_config, modifiers, adducts, mols):

--- a/annotation_pipeline/molecular_db_local.py
+++ b/annotation_pipeline/molecular_db_local.py
@@ -86,6 +86,10 @@ def store_formula_segments(storage, formulas_df):
         return storage.put_cobject(segm.to_msgpack())
 
     with ThreadPoolExecutor(max_workers=128) as pool:
-        return list(pool.map(_store, segm_list))
+        formula_cobjects = list(pool.map(_store, segm_list))
+
+    assert len(formula_cobjects) == len(set(co.key for co in formula_cobjects)), 'Duplicate CloudObjects in formula_cobjects'
+
+    return formula_cobjects
 
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -156,7 +156,7 @@ class Pipeline(object):
         self.ds_segm_n = len(self.ds_segms_cobjects)
         self.is_intensive_dataset = self.ds_segm_n * self.ds_segm_size_mb > 5000
 
-        if debug_validate:
+        if debug_validate and vm_algorithm:
             validate_ds_segments(
                 self.pywren_executor, self.imzml_reader, self.ds_segments_bounds,
                 self.ds_segms_cobjects, self.ds_segms_len,
@@ -192,7 +192,7 @@ class Pipeline(object):
                 self.image_gen_config['ppm']
             )
 
-    def annotate(self, use_cache=True):
+    def annotate(self, use_cache=True, vm_algorithm=True):
         annotations_cache_key = ':ds/:db/annotate.cache'
 
         if use_cache and self.cacher.exists(annotations_cache_key):
@@ -203,7 +203,8 @@ class Pipeline(object):
             memory_capacity_mb = 4096 if self.is_intensive_dataset else 2048
             process_centr_segment = create_process_segment(self.ds_segms_cobjects,
                                                            self.ds_segments_bounds, self.ds_segms_len, self.imzml_reader,
-                                                           self.image_gen_config, memory_capacity_mb, self.ds_segm_size_mb)
+                                                           self.image_gen_config, memory_capacity_mb, self.ds_segm_size_mb,
+                                                           vm_algorithm)
 
             futures = self.pywren_executor.map(process_centr_segment, self.db_segms_cobjects, runtime_memory=memory_capacity_mb)
             formula_metrics_list, images_cloud_objs = zip(*self.pywren_executor.get_result(futures))

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -31,7 +31,10 @@ class Pipeline(object):
         storage_handler.bucket = self.config['pywren']['storage_bucket']
         self.storage = storage_handler.get_client()
 
-        self.cacher = PipelineCacher(self.pywren_executor, self.ds_config["name"], self.db_config["name"])
+        cache_namespace = 'vm' if vm_algorithm else 'function'
+        self.cacher = PipelineCacher(
+            self.pywren_executor, cache_namespace, self.ds_config["name"], self.db_config["name"]
+        )
         if not self.use_cache:
             self.cacher.clean()
 

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -67,20 +67,28 @@ class Pipeline(object):
 
             if use_cache and self.cacher.exists(cache_key):
                 self.formula_cobjects, self.db_data_cobjects = self.cacher.load(cache_key)
+                logger.info(f'Loaded {len(self.formula_cobjects)} formula segments and'
+                            f' {len(self.db_data_cobjects)} db_data objects from cache')
             else:
                 self.formula_cobjects, self.db_data_cobjects = build_database_local(
                     self.storage, db_bucket, self.db_config, self.ds_config
                 )
+                logger.info(f'Built {len(self.formula_cobjects)} formula segments and'
+                            f' {len(self.db_data_cobjects)} db_data objects')
                 self.cacher.save((self.formula_cobjects, self.db_data_cobjects), cache_key)
         else:
             cache_key = ':db/build_database.cache'
 
             if use_cache and self.cacher.exists(cache_key):
                 self.formula_cobjects, self.formula_to_id_cobjects = self.cacher.load(cache_key)
+                logger.info(f'Loaded {len(self.formula_cobjects)} formula segments and'
+                            f' {len(self.formula_to_id_cobjects)} formula-to-id chunks from cache')
             else:
                 self.formula_cobjects, self.formula_to_id_cobjects = build_database(
                     self.pywren_executor, db_bucket, self.db_config
                 )
+                logger.info(f'Built {len(self.formula_cobjects)} formula segments and'
+                            f' {len(self.formula_to_id_cobjects)} formula-to-id chunks')
                 self.cacher.save((self.formula_cobjects, self.formula_to_id_cobjects), cache_key)
 
         if debug_validate:
@@ -90,10 +98,12 @@ class Pipeline(object):
         cache_key = ':ds/:db/calculate_centroids.cache'
         if use_cache and self.cacher.exists(cache_key):
             self.peaks_cobjects = self.cacher.load(cache_key)
+            logger.info(f'Loaded {len(self.peaks_cobjects)} centroid chunks from cache')
         else:
             self.peaks_cobjects = calculate_centroids(
                 self.pywren_executor, self.formula_cobjects, self.ds_config
             )
+            logger.info(f'Calculated {len(self.peaks_cobjects)} centroid chunks')
             self.cacher.save(self.peaks_cobjects, cache_key)
 
         if debug_validate:

--- a/annotation_pipeline/pipeline.py
+++ b/annotation_pipeline/pipeline.py
@@ -43,7 +43,7 @@ class Pipeline(object):
         self.run_fdr()
 
     def load_ds(self):
-        imzml_cache_key = f'{self.cacher.prefix}/load_ds.cache'
+        imzml_cache_key = 'load_ds.cache'
 
         if self.cacher.exists(imzml_cache_key):
             self.imzml_reader, self.imzml_cobject = self.cacher.load(imzml_cache_key)
@@ -54,7 +54,7 @@ class Pipeline(object):
             self.cacher.save((self.imzml_reader, self.imzml_cobject), imzml_cache_key)
 
     def split_ds(self):
-        ds_chunks_cache_key = f'{self.cacher.prefix}/split_ds.cache'
+        ds_chunks_cache_key = 'split_ds.cache'
 
         if self.cacher.exists(ds_chunks_cache_key):
             self.ds_chunks_cobjects = self.cacher.load(ds_chunks_cache_key)
@@ -66,7 +66,7 @@ class Pipeline(object):
             self.cacher.save(self.ds_chunks_cobjects, ds_chunks_cache_key)
 
     def segment_ds(self):
-        ds_segments_cache_key = f'{self.cacher.prefix}/segment_ds.cache'
+        ds_segments_cache_key = 'segment_ds.cache'
 
         if self.cacher.exists(ds_segments_cache_key):
             self.ds_segments_bounds, self.ds_segms_cobjects, self.ds_segms_len = \
@@ -87,7 +87,7 @@ class Pipeline(object):
 
     def segment_centroids(self):
         mz_min, mz_max = self.ds_segments_bounds[0, 0], self.ds_segments_bounds[-1, 1]
-        db_segments_cache_key = f'{self.cacher.prefix}/segment_centroids.cache'
+        db_segments_cache_key = 'segment_centroids.cache'
 
         if self.cacher.exists(db_segments_cache_key):
             self.clip_centr_chunks_cobjects, self.db_segms_cobjects = self.cacher.load(db_segments_cache_key)
@@ -111,7 +111,7 @@ class Pipeline(object):
         self.centr_segm_n = len(self.db_segms_cobjects)
 
     def annotate(self):
-        annotations_cache_key = f'{self.cacher.prefix}/annotate.cache'
+        annotations_cache_key = 'annotate.cache'
 
         if self.cacher.exists(annotations_cache_key):
             self.formula_metrics_df, self.images_cloud_objs = self.cacher.load(annotations_cache_key)
@@ -132,7 +132,7 @@ class Pipeline(object):
             self.cacher.save((self.formula_metrics_df, self.images_cloud_objs), annotations_cache_key)
 
     def run_fdr(self):
-        fdrs_cache_key = f'{self.cacher.prefix}/run_fdr.cache'
+        fdrs_cache_key = 'run_fdr.cache'
 
         if self.cacher.exists(fdrs_cache_key):
             self.rankings_df, self.fdrs = self.cacher.load(fdrs_cache_key)

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -495,8 +495,8 @@ def validate_ds_segments(pw, imzml_reader, ds_segments_bounds, ds_segms_cobjects
     results = pw.get_result(futures)
 
     segms_df = pd.DataFrame(results)
-    segms_df['min_bound'] = ds_segments_bounds[:, 0]
-    segms_df['max_bound'] = ds_segments_bounds[:, 1]
+    segms_df['min_bound'] = np.concatenate([[0], ds_segments_bounds[1:, 0]])
+    segms_df['max_bound'] = np.concatenate([ds_segments_bounds[:-1, 1], [100000]])
     segms_df['expected_len'] = ds_segms_len
 
     with pd.option_context('display.max_rows', None, 'display.max_columns', None, 'display.width', 1000):
@@ -509,6 +509,11 @@ def validate_ds_segments(pw, imzml_reader, ds_segments_bounds, ds_segms_cobjects
         if not bad_len.empty:
             logger.warning('segment_spectra lengths don\'t match ds_segms_len:')
             logger.warning(bad_len)
+
+        unsorted = segms_df[~segms_df.is_sorted]
+        if not unsorted.empty:
+            logger.warning('segment_spectra produced unsorted segments:')
+            logger.warning(unsorted)
 
         total_len = segms_df.n_rows.sum()
         expected_total_len = np.sum(imzml_reader.mzLengths)

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -9,7 +9,7 @@ import math
 import requests
 from pyimzml.ImzMLParser import ImzMLParser
 
-from annotation_pipeline.image import choose_ds_segments
+from annotation_pipeline.image import choose_ds_segments, read_ds_segment
 from annotation_pipeline.utils import logger, get_pixel_indices, append_pywren_stats, \
     read_cloud_object_with_retry, read_ranges_from_url
 from concurrent.futures import ThreadPoolExecutor
@@ -472,18 +472,13 @@ def validate_centroid_segments(pw, db_segms_cobjects, ds_segms_bounds, ppm):
 
 def validate_ds_segments(pw, imzml_reader, ds_segments_bounds, ds_segms_cobjects, ds_segms_len, vm_algorithm):
     def get_segm_stats(cobject, storage):
-        if vm_algorithm:
-            segm = pd.read_msgpack(storage.get_cobject(cobject, stream=True))
+        segm = read_ds_segment(cobject, vm_algorithm, storage)
+        assert (segm.columns == ['mz', 'int', 'sp_i']).all(), f'Wrong ds_segm columns: {segm.columns}'
+        assert isinstance(segm.index, pd.RangeIndex), f'ds_segm does not have a RangeIndex {segm.index}'
 
-            assert (segm.columns == ['mz', 'int', 'sp_i']).all(), f'Wrong ds_segm columns: {segm.columns}'
-            assert isinstance(segm.index, pd.RangeIndex), 'ds_segm does not have a RangeIndex'
+        if vm_algorithm:
             assert segm.dtypes[1] == np.float32, 'ds_segm.int should be float32'
             assert segm.dtypes[2] == np.uint32, 'ds_segm.sp_i should be uint32'
-        else:
-            segm = msgpack.load(storage.get_cobject(cobject, stream=True))
-            if isinstance(segm, list):
-                segm = np.concatenate(segm)
-                segm = pd.DataFrame({'mz': segm[:, 1]})
 
         return pd.Series({
             'n_rows': len(segm),

--- a/annotation_pipeline/segment.py
+++ b/annotation_pipeline/segment.py
@@ -239,7 +239,8 @@ def clip_centr_df(pw, peaks_cobjects, mz_min, mz_max):
         return clip_centr_chunk_cobject, centr_df_chunk.shape[0]
 
     memory_capacity_mb = 512
-    futures = pw.map(clip_centr_df_chunk, enumerate(peaks_cobjects), runtime_memory=memory_capacity_mb)
+    futures = pw.map(clip_centr_df_chunk, list(enumerate(peaks_cobjects)),
+                     runtime_memory=memory_capacity_mb)
     clip_centr_chunks_cobjects, centr_n = list(zip(*pw.get_result(futures)))
     append_pywren_stats(futures, memory_mb=memory_capacity_mb, cloud_objects_n=len(futures))
 

--- a/annotation_pipeline/segment_ds_vm.py
+++ b/annotation_pipeline/segment_ds_vm.py
@@ -1,3 +1,4 @@
+from tempfile import TemporaryDirectory
 import requests
 from pyimzml.ImzMLParser import ImzMLParser
 from concurrent.futures.thread import ThreadPoolExecutor
@@ -5,15 +6,6 @@ from pathlib import Path
 import numpy as np
 from time import time
 import pandas as pd
-from shutil import rmtree
-
-IMZML_URL = 'https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.imzML'
-IBD_URL = 'https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.ibd'
-DATASET_PATH = '/data/metabolomics/ds'
-SEGMENTS_PATH = '/data/metabolomics/ds/segms'
-SEGMENT_SIZE_MB = 5
-SEGMENTS_BUCKET_NAME = 'omeruseast'
-SEGMENTS_COS_PREFIX = 'metabolomics/vm_ds_segments'
 
 from pywren_ibm_cloud.storage import InternalStorage
 from pywren_ibm_cloud.config import default_config, extract_storage_config
@@ -24,23 +16,23 @@ STORAGE = InternalStorage(STORAGE_CONFIG).storage_handler
 
 
 def download_dataset(imzml_url, idb_url, local_path, chunk_size=1024 ** 3):
-    def _download(url, filename):
+    def _download(url, path):
         with requests.get(url, stream=True) as r:
             r.raise_for_status()
-            with open(filename, 'wb') as f:
+            with path.open('wb') as f:
                 for chunk in r.iter_content(chunk_size=chunk_size):
                     f.write(chunk)
 
     Path(local_path).mkdir(exist_ok=True)
-    imzml_path = f'{local_path}/ds.imzML'
-    ibd_path = f'{local_path}/ds.ibd'
+    imzml_path = local_path / 'ds.imzML'
+    ibd_path = local_path / 'ds.ibd'
 
     with ThreadPoolExecutor() as ex:
         ex.submit(_download, imzml_url, imzml_path)
         ex.submit(_download, idb_url, ibd_path)
 
-    imzml_size = Path(imzml_path).stat().st_size / (1024 ** 2)
-    ibd_size = Path(ibd_path).stat().st_size / (1024 ** 2)
+    imzml_size = imzml_path.stat().st_size / (1024 ** 2)
+    ibd_size = ibd_path.stat().st_size / (1024 ** 2)
     return imzml_size, ibd_size
 
 
@@ -67,14 +59,15 @@ def parse_dataset_chunks(imzml_parser, coordinates, max_size=512 * 1024 ** 2):
         return pixel_indices
 
     sp_id_to_idx = get_pixel_indices(coordinates)
-    dtype = imzml_parser.mzPrecision
 
     def sort_dataset_chunk(sp_inds_list, mzs_list, ints_list):
         mzs = np.concatenate(mzs_list)
         by_mz = np.argsort(mzs)
-        sp_mz_int_buf = np.array([np.concatenate(sp_inds_list)[by_mz],
-                                  mzs[by_mz],
-                                  np.concatenate(ints_list)[by_mz]], dtype).T
+        sp_mz_int_buf = pd.DataFrame({
+            'mz': mzs[by_mz],
+            'int': np.concatenate(ints_list)[by_mz].astype(np.float32),
+            'sp_i': np.concatenate(sp_inds_list)[by_mz],
+        })
         return sp_mz_int_buf
 
     curr_sp_i = 0
@@ -83,12 +76,12 @@ def parse_dataset_chunks(imzml_parser, coordinates, max_size=512 * 1024 ** 2):
     estimated_size_mb = 0
     for x, y in coordinates:
         mzs_, ints_ = imzml_parser.getspectrum(curr_sp_i)
-        mzs_, ints_ = map(np.array, [mzs_, ints_])
-        sp_idx = sp_id_to_idx[curr_sp_i]
-        sp_inds_list.append(np.ones_like(mzs_) * sp_idx)
+        ints_ = ints_.astype(np.float32)
+        sp_idx = np.ones_like(mzs_, dtype=np.uint32) * sp_id_to_idx[curr_sp_i]
         mzs_list.append(mzs_)
         ints_list.append(ints_)
-        estimated_size_mb += 2 * mzs_.nbytes + ints_.nbytes
+        sp_inds_list.append(sp_idx)
+        estimated_size_mb += mzs_.nbytes + ints_.nbytes + sp_idx.nbytes
         curr_sp_i += 1
         if estimated_size_mb > max_size:
             yield sort_dataset_chunk(sp_inds_list, mzs_list, ints_list)
@@ -115,10 +108,8 @@ def define_ds_segments(imzml_parser, sp_n, ds_segm_size_mb=5, sample_sp_n=1000):
     spectra_mzs = np.array([mz for sp_id, mzs, ints in spectra_sample for mz in mzs])
     total_n_mz = spectra_mzs.shape[0] / sample_ratio
 
-    float_prec = 4 if imzml_parser.mzPrecision == 'f' else 8
-    segm_arr_columns = 3
-    segm_n = segm_arr_columns * (total_n_mz * float_prec) // (ds_segm_size_mb * 2 ** 20)
-    segm_n = max(1, int(segm_n))
+    row_size = (4 if imzml_parser.mzPrecision == 'f' else 8) + 4 + 4
+    segm_n = int(np.ceil(total_n_mz * row_size / (ds_segm_size_mb * 2 ** 20)))
 
     segm_bounds_q = [i * 1 / segm_n for i in range(0, segm_n + 1)]
     segm_lower_bounds = [np.quantile(spectra_mzs, q) for q in segm_bounds_q]
@@ -134,64 +125,82 @@ def define_ds_segments(imzml_parser, sp_n, ds_segm_size_mb=5, sample_sp_n=1000):
 def segment_spectra_chunk(sp_mz_int_buf, ds_segments_bounds, ds_segments_path):
     def _segment(args):
         segm_i, (l, r) = args
-        segm_start, segm_end = np.searchsorted(sp_mz_int_buf[:, 1], (l, r))
-        pd.to_msgpack(f'{ds_segments_path}/ds_segm_{segm_i:04}.msgpack',
-                      sp_mz_int_buf[segm_start:segm_end],
-                      append=True)
+        segm_start, segm_end = np.searchsorted(sp_mz_int_buf.mz.values, (l, r))
+        segm = sp_mz_int_buf.iloc[segm_start:segm_end]
+        segm.to_msgpack(ds_segments_path / f'ds_segm_{segm_i:04}.msgpack', append=True)
+        return segm_i, len(segm)
 
     with ThreadPoolExecutor() as pool:
-        pool.map(_segment, enumerate(ds_segments_bounds))
+        return list(pool.map(_segment, enumerate(ds_segments_bounds)))
 
 
-def upload_segments(ds_segments_path, segments_n, segments_bucket_name, segments_prefix, storage):
+def upload_segments(storage, ds_segments_path, segments_n):
     def _upload(segm_i):
-        storage.cos_client.upload_file(Filename=f'{ds_segments_path}/ds_segm_{segm_i:04}.msgpack',
-                                       Bucket=segments_bucket_name,
-                                       Key=f'{segments_prefix}/{segm_i}.msgpack')
+        return storage.put_cobject((ds_segments_path / f'ds_segm_{segm_i:04}.msgpack').open('rb'))
 
     with ThreadPoolExecutor() as pool:
-        pool.map(_upload, range(segments_n))
+        ds_segms_cobjects = list(pool.map(_upload, range(segments_n)))
+
+    assert len(ds_segms_cobjects) == len(set(co.key for co in ds_segms_cobjects)), 'Duplicate CloudObjects in ds_segms_cobjects'
+
+    return ds_segms_cobjects
 
 
-if __name__ == '__main__':
-    rmtree(DATASET_PATH, ignore_errors=True)
-    Path(DATASET_PATH).mkdir(parents=True)
-
+def load_and_split_ds_vm(storage, ds_config, ds_segm_size_mb):
     start = time()
 
-    print('Downloading dataset...', end=' ', flush=True)
-    t = time()
-    imzml_size, ibd_size = download_dataset(IMZML_URL, IBD_URL, DATASET_PATH)
-    print('DONE {:.2f} sec'.format(time() - t))
-    print(' * imzML size: {:.2f} mb'.format(imzml_size))
-    print(' * ibd size: {:.2f} mb'.format(ibd_size))
+    with TemporaryDirectory() as tmp_dir:
+        imzml_dir = Path(tmp_dir) / 'imzml'
+        imzml_dir.mkdir()
+        segments_dir = Path(tmp_dir) / 'segments'
+        segments_dir.mkdir()
 
-    print('Loading parser...', end=' ', flush=True)
-    t = time()
-    imzml_parser = ImzMLParser(ds_imzml_path(DATASET_PATH))
-    print('DONE {:.2f} sec'.format(time() - t))
+        print('Downloading dataset...', end=' ', flush=True)
+        t = time()
+        imzml_size, ibd_size = download_dataset(ds_config['imzml_path'], ds_config['ibd_path'], imzml_dir)
+        print('DONE {:.2f} sec'.format(time() - t))
+        print(' * imzML size: {:.2f} mb'.format(imzml_size))
+        print(' * ibd size: {:.2f} mb'.format(ibd_size))
 
-    coordinates = [coo[:2] for coo in imzml_parser.coordinates]
-    sp_n = len(coordinates)
+        print('Loading parser...', end=' ', flush=True)
+        t = time()
+        imzml_parser = ImzMLParser(ds_imzml_path(imzml_dir))
+        imzml_reader = imzml_parser.portable_spectrum_reader()
+        print('DONE {:.2f} sec'.format(time() - t))
 
-    print('Defining segments bounds...', end=' ', flush=True)
-    t = time()
-    ds_segments_bounds = define_ds_segments(imzml_parser, sp_n, ds_segm_size_mb=SEGMENT_SIZE_MB)
-    segments_n = len(ds_segments_bounds)
-    print('DONE {:.2f} sec'.format(time() - t))
-    print(' * segments number:', segments_n)
+        coordinates = [coo[:2] for coo in imzml_parser.coordinates]
+        sp_n = len(coordinates)
 
-    print('Segmenting...', end=' ', flush=True)
-    t = time()
-    rmtree(SEGMENTS_PATH, ignore_errors=True)
-    Path(SEGMENTS_PATH).mkdir(parents=True)
-    for sp_mz_int_buf in parse_dataset_chunks(imzml_parser, coordinates):
-        segment_spectra_chunk(sp_mz_int_buf, ds_segments_bounds, SEGMENTS_PATH)
-    print('DONE {:.2f} sec'.format(time() - t))
+        print('Defining segments bounds...', end=' ', flush=True)
+        t = time()
+        ds_segments_bounds = define_ds_segments(imzml_parser, sp_n, ds_segm_size_mb=ds_segm_size_mb)
+        segments_n = len(ds_segments_bounds)
+        print('DONE {:.2f} sec'.format(time() - t))
+        print(' * segments number:', segments_n)
 
-    print('Uploading segments...', end=' ', flush=True)
-    t = time()
-    upload_segments(SEGMENTS_PATH, segments_n, SEGMENTS_BUCKET_NAME, SEGMENTS_COS_PREFIX, STORAGE)
-    print('DONE {:.2f} sec'.format(time() - t))
+        print('Segmenting...', end=' ', flush=True)
+        t = time()
+        segm_sizes = []
+        for sp_mz_int_buf in parse_dataset_chunks(imzml_parser, coordinates):
+            chunk_segm_sizes = segment_spectra_chunk(sp_mz_int_buf, ds_segments_bounds, segments_dir)
+            segm_sizes.extend(chunk_segm_sizes)
+        ds_segms_len = (
+             pd.DataFrame(segm_sizes, columns=['segm_i', 'segm_size'])
+            .groupby('segm_i')
+            .segm_size
+            .sum()
+            .sort_index()
+            .values
+        )
 
-    print('--- {:.2f} sec ---'.format(time() - start))
+        print('DONE {:.2f} sec'.format(time() - t))
+
+        print('Uploading segments...', end=' ', flush=True)
+        t = time()
+        ds_segms_cobjects = upload_segments(storage, segments_dir, segments_n)
+        print('DONE {:.2f} sec'.format(time() - t))
+
+        print('--- {:.2f} sec ---'.format(time() - start))
+
+        return imzml_reader, ds_segments_bounds, ds_segms_cobjects, ds_segms_len
+

--- a/annotation_pipeline/segment_ds_vm.py
+++ b/annotation_pipeline/segment_ds_vm.py
@@ -1,0 +1,197 @@
+import requests
+from pyimzml.ImzMLParser import ImzMLParser
+from concurrent.futures.thread import ThreadPoolExecutor
+from pathlib import Path
+import numpy as np
+from time import time
+import pandas as pd
+from shutil import rmtree
+
+IMZML_URL = 'https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.imzML'
+IBD_URL = 'https://s3.eu-de.cloud-object-storage.appdomain.cloud/metaspace-public/metabolomics/ds/Brain02_Bregma1-42_02/Brain02_Bregma1-42_02.ibd'
+DATASET_PATH = '/data/metabolomics/ds'
+SEGMENTS_PATH = '/data/metabolomics/ds/segms'
+SEGMENT_SIZE_MB = 5
+SEGMENTS_BUCKET_NAME = 'omeruseast'
+SEGMENTS_COS_PREFIX = 'metabolomics/vm_ds_segments'
+
+from pywren_ibm_cloud.storage import InternalStorage
+from pywren_ibm_cloud.config import default_config, extract_storage_config
+
+PYWREN_CONFIG = default_config()
+STORAGE_CONFIG = extract_storage_config(PYWREN_CONFIG)
+STORAGE = InternalStorage(STORAGE_CONFIG).storage_handler
+
+
+def download_dataset(imzml_url, idb_url, local_path, chunk_size=1024 ** 3):
+    def _download(url, filename):
+        with requests.get(url, stream=True) as r:
+            r.raise_for_status()
+            with open(filename, 'wb') as f:
+                for chunk in r.iter_content(chunk_size=chunk_size):
+                    f.write(chunk)
+
+    Path(local_path).mkdir(exist_ok=True)
+    imzml_path = f'{local_path}/ds.imzML'
+    ibd_path = f'{local_path}/ds.ibd'
+
+    with ThreadPoolExecutor() as ex:
+        ex.submit(_download, imzml_url, imzml_path)
+        ex.submit(_download, idb_url, ibd_path)
+
+    imzml_size = Path(imzml_path).stat().st_size / (1024 ** 2)
+    ibd_size = Path(ibd_path).stat().st_size / (1024 ** 2)
+    return imzml_size, ibd_size
+
+
+def ds_imzml_path(ds_data_path):
+    return next(str(p) for p in Path(ds_data_path).iterdir()
+                if str(p).lower().endswith('.imzml'))
+
+
+def parse_dataset_chunks(imzml_parser, coordinates, max_size=512 * 1024 ** 2):
+    def ds_dims(coordinates):
+        min_x, min_y = np.amin(coordinates, axis=0)
+        max_x, max_y = np.amax(coordinates, axis=0)
+        nrows, ncols = max_y - min_y + 1, max_x - min_x + 1
+        return nrows, ncols
+
+    def get_pixel_indices(coordinates):
+        _coord = np.array(coordinates)
+        _coord = np.around(_coord, 5)
+        _coord -= np.amin(_coord, axis=0)
+
+        _, ncols = ds_dims(coordinates)
+        pixel_indices = _coord[:, 1] * ncols + _coord[:, 0]
+        pixel_indices = pixel_indices.astype(np.int32)
+        return pixel_indices
+
+    sp_id_to_idx = get_pixel_indices(coordinates)
+    dtype = imzml_parser.mzPrecision
+
+    def sort_dataset_chunk(sp_inds_list, mzs_list, ints_list):
+        mzs = np.concatenate(mzs_list)
+        by_mz = np.argsort(mzs)
+        sp_mz_int_buf = np.array([np.concatenate(sp_inds_list)[by_mz],
+                                  mzs[by_mz],
+                                  np.concatenate(ints_list)[by_mz]], dtype).T
+        return sp_mz_int_buf
+
+    curr_sp_i = 0
+    sp_inds_list, mzs_list, ints_list = [], [], []
+
+    estimated_size_mb = 0
+    for x, y in coordinates:
+        mzs_, ints_ = imzml_parser.getspectrum(curr_sp_i)
+        mzs_, ints_ = map(np.array, [mzs_, ints_])
+        sp_idx = sp_id_to_idx[curr_sp_i]
+        sp_inds_list.append(np.ones_like(mzs_) * sp_idx)
+        mzs_list.append(mzs_)
+        ints_list.append(ints_)
+        estimated_size_mb += 2 * mzs_.nbytes + ints_.nbytes
+        curr_sp_i += 1
+        if estimated_size_mb > max_size:
+            yield sort_dataset_chunk(sp_inds_list, mzs_list, ints_list)
+            sp_inds_list, mzs_list, ints_list = [], [], []
+            estimated_size_mb = 0
+
+    if len(sp_inds_list) > 0:
+        yield sort_dataset_chunk(sp_inds_list, mzs_list, ints_list)
+
+
+def define_ds_segments(imzml_parser, sp_n, ds_segm_size_mb=5, sample_sp_n=1000):
+    sample_ratio = sample_sp_n / sp_n
+
+    def spectra_sample_gen(imzml_parser, sample_ratio):
+        sp_n = len(imzml_parser.coordinates)
+        sample_size = int(sp_n * sample_ratio)
+        sample_sp_inds = np.random.choice(np.arange(sp_n), sample_size)
+        for sp_idx in sample_sp_inds:
+            mzs, ints = imzml_parser.getspectrum(sp_idx)
+            yield sp_idx, mzs, ints
+
+    spectra_sample = list(spectra_sample_gen(imzml_parser, sample_ratio=sample_ratio))
+
+    spectra_mzs = np.array([mz for sp_id, mzs, ints in spectra_sample for mz in mzs])
+    total_n_mz = spectra_mzs.shape[0] / sample_ratio
+
+    float_prec = 4 if imzml_parser.mzPrecision == 'f' else 8
+    segm_arr_columns = 3
+    segm_n = segm_arr_columns * (total_n_mz * float_prec) // (ds_segm_size_mb * 2 ** 20)
+    segm_n = max(1, int(segm_n))
+
+    segm_bounds_q = [i * 1 / segm_n for i in range(0, segm_n + 1)]
+    segm_lower_bounds = [np.quantile(spectra_mzs, q) for q in segm_bounds_q]
+    ds_segments_bounds = np.array(list(zip(segm_lower_bounds[:-1], segm_lower_bounds[1:])))
+
+    max_mz_value = 10 ** 5
+    ds_segments_bounds[0, 0] = 0
+    ds_segments_bounds[-1, 1] = max_mz_value
+
+    return ds_segments_bounds
+
+
+def segment_spectra_chunk(sp_mz_int_buf, ds_segments_bounds, ds_segments_path):
+    def _segment(args):
+        segm_i, (l, r) = args
+        segm_start, segm_end = np.searchsorted(sp_mz_int_buf[:, 1], (l, r))
+        pd.to_msgpack(f'{ds_segments_path}/ds_segm_{segm_i:04}.msgpack',
+                      sp_mz_int_buf[segm_start:segm_end],
+                      append=True)
+
+    with ThreadPoolExecutor() as pool:
+        pool.map(_segment, enumerate(ds_segments_bounds))
+
+
+def upload_segments(ds_segments_path, segments_n, segments_bucket_name, segments_prefix, storage):
+    def _upload(segm_i):
+        storage.cos_client.upload_file(Filename=f'{ds_segments_path}/ds_segm_{segm_i:04}.msgpack',
+                                       Bucket=segments_bucket_name,
+                                       Key=f'{segments_prefix}/{segm_i}.msgpack')
+
+    with ThreadPoolExecutor() as pool:
+        pool.map(_upload, range(segments_n))
+
+
+if __name__ == '__main__':
+    rmtree(DATASET_PATH, ignore_errors=True)
+    Path(DATASET_PATH).mkdir(parents=True)
+
+    start = time()
+
+    print('Downloading dataset...', end=' ', flush=True)
+    t = time()
+    imzml_size, ibd_size = download_dataset(IMZML_URL, IBD_URL, DATASET_PATH)
+    print('DONE {:.2f} sec'.format(time() - t))
+    print(' * imzML size: {:.2f} mb'.format(imzml_size))
+    print(' * ibd size: {:.2f} mb'.format(ibd_size))
+
+    print('Loading parser...', end=' ', flush=True)
+    t = time()
+    imzml_parser = ImzMLParser(ds_imzml_path(DATASET_PATH))
+    print('DONE {:.2f} sec'.format(time() - t))
+
+    coordinates = [coo[:2] for coo in imzml_parser.coordinates]
+    sp_n = len(coordinates)
+
+    print('Defining segments bounds...', end=' ', flush=True)
+    t = time()
+    ds_segments_bounds = define_ds_segments(imzml_parser, sp_n, ds_segm_size_mb=SEGMENT_SIZE_MB)
+    segments_n = len(ds_segments_bounds)
+    print('DONE {:.2f} sec'.format(time() - t))
+    print(' * segments number:', segments_n)
+
+    print('Segmenting...', end=' ', flush=True)
+    t = time()
+    rmtree(SEGMENTS_PATH, ignore_errors=True)
+    Path(SEGMENTS_PATH).mkdir(parents=True)
+    for sp_mz_int_buf in parse_dataset_chunks(imzml_parser, coordinates):
+        segment_spectra_chunk(sp_mz_int_buf, ds_segments_bounds, SEGMENTS_PATH)
+    print('DONE {:.2f} sec'.format(time() - t))
+
+    print('Uploading segments...', end=' ', flush=True)
+    t = time()
+    upload_segments(SEGMENTS_PATH, segments_n, SEGMENTS_BUCKET_NAME, SEGMENTS_COS_PREFIX, STORAGE)
+    print('DONE {:.2f} sec'.format(time() - t))
+
+    print('--- {:.2f} sec ---'.format(time() - start))

--- a/annotation_pipeline/segment_ds_vm.py
+++ b/annotation_pipeline/segment_ds_vm.py
@@ -200,7 +200,7 @@ def load_and_split_ds_vm(storage, ds_config, ds_segm_size_mb, sort_memory=2**32)
         segments_dir = Path(tmp_dir) / 'segments'
         segments_dir.mkdir()
 
-        logger.debug('Downloading dataset...')
+        logger.info('Downloading dataset...')
         t = time()
         imzml_path, ibd_path = download_dataset(
             ds_config['imzml_path'], ds_config['ibd_path'], imzml_dir, storage

--- a/annotation_pipeline/segment_ds_vm.py
+++ b/annotation_pipeline/segment_ds_vm.py
@@ -125,7 +125,7 @@ def segment_spectra_chunk(chunk_i, sp_mz_int_buf, ds_segments_bounds, ds_segment
         segm_i, (l, r) = args
         segm_start, segm_end = np.searchsorted(sp_mz_int_buf.mz.values, (l, r))
         segm = sp_mz_int_buf.iloc[segm_start:segm_end]
-        segm.to_msgpack(ds_segments_path / f'ds_segm_{segm_i:04}_{chunk_i}.msgpack')
+        segm.to_msgpack(ds_segments_path / f'ds_segm_{segm_i:04}_{chunk_i:04}.msgpack')
         return segm_i, len(segm)
 
     with ThreadPoolExecutor(4) as pool:
@@ -142,7 +142,7 @@ def parse_and_segment_chunk(args):
 def upload_segments(storage, ds_segments_path, chunks_n, segments_n):
     def _upload(segm_i):
         segm = pd.concat([
-            pd.read_msgpack(ds_segments_path / f'ds_segm_{segm_i:04}_{chunk_i}.msgpack')
+            pd.read_msgpack(ds_segments_path / f'ds_segm_{segm_i:04}_{chunk_i:04}.msgpack')
             for chunk_i in range(chunks_n)
         ], ignore_index=True, sort=False)
         segm.sort_values('mz', inplace=True)

--- a/config.json.template
+++ b/config.json.template
@@ -12,14 +12,13 @@
   },
   "pywren": {
     "storage_bucket": "****",
+    "storage_backend": "ibm_cos",
     "runtime": "ibmfunctions/pywren-metabolomics:3.6",
     "include_modules": ["annotation_pipeline"],
     "runtime_timeout": 1200,
     "data_limit": false
   },
   "storage": {
-    "ds_bucket": "****",
-    "db_bucket": "****",
-    "output_bucket": "****"
+    "db_bucket": "****"
   }
 }

--- a/experiment-1-typical.ipynb
+++ b/experiment-1-typical.ipynb
@@ -183,7 +183,8 @@
    },
    "outputs": [],
    "source": [
-    "from annotation_pipeline.molecular_db import build_database, calculate_centroids, upload_mol_dbs_from_dir"
+    "from annotation_pipeline.molecular_db import upload_mol_dbs_from_dir\n",
+    "from annotation_pipeline.pipeline import Pipeline"
    ]
   },
   {
@@ -205,35 +206,19 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    },
-    "scrolled": true
-   },
    "outputs": [],
    "source": [
-    "build_database(config, input_db)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
+    "# Process database and pre-calculate centroids (not benchmarked because usually this step is cached)\n",
+    "pipeline = Pipeline(config, input_ds, input_db, use_cache=False)\n",
+    "pipeline.build_database()\n",
+    "pipeline.calculate_centroids()"
+   ],
    "metadata": {
-    "hidden": true,
+    "collapsed": false,
     "pycharm": {
-     "metadata": false,
      "name": "#%%\n"
     }
-   },
-   "outputs": [],
-   "source": [
-    "polarity = input_ds['polarity']\n",
-    "isocalc_sigma = input_ds['isocalc_sigma']\n",
-    "calculate_centroids(config, input_db, polarity, isocalc_sigma)"
-   ]
+   }
   },
   {
    "cell_type": "markdown",
@@ -274,39 +259,16 @@
   {
    "cell_type": "code",
    "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "from annotation_pipeline.pipeline import Pipeline"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "pipeline = Pipeline(config, input_ds, input_db, use_cache=False)"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
    "metadata": {},
    "outputs": [],
    "source": [
     "start_time = datetime.now()\n",
-    "pipeline()\n",
+    "pipeline.load_ds()\n",
+    "pipeline.split_ds()\n",
+    "pipeline.segment_ds()\n",
+    "pipeline.segment_centroids()\n",
+    "pipeline.annotate()\n",
+    "pipeline.run_fdr()\n",
     "results_df = pipeline.get_results()\n",
     "finish_time = datetime.now()"
    ]

--- a/experiment-2-interactive.ipynb
+++ b/experiment-2-interactive.ipynb
@@ -172,9 +172,9 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "from annotation_pipeline.molecular_db import build_database, calculate_centroids, upload_mol_db_from_file\n",
+    "from annotation_pipeline.molecular_db import upload_mol_db_from_file\n",
     "from annotation_pipeline.pipeline import Pipeline\n",
-    "from datetime import datetime"
+    "from datetime import datetime\n"
    ]
   },
   {
@@ -236,10 +236,8 @@
     "# Process new molecules:\n",
     "## Upload list of molecules (in a real scenario this list would change every iteration, so this isn't part of setup)\n",
     "upload_mol_db_from_file(config, config['storage']['db_bucket'], exp_db_path, 'metabolomics/db/mol_db5.csv')\n",
-    "build_database(config, input_db)\n",
-    "polarity = input_ds['polarity']\n",
-    "isocalc_sigma = input_ds['isocalc_sigma']\n",
-    "calculate_centroids(config, input_db, polarity, isocalc_sigma)\n",
+    "pipeline.build_database()\n",
+    "pipeline.calculate_centroids()\n",
     "pipeline.segment_centroids()\n",
     "\n",
     "# Run Annotation:\n",

--- a/experiment-3-large.ipynb
+++ b/experiment-3-large.ipynb
@@ -172,7 +172,7 @@
    "source": [
     "import pandas as pd\n",
     "from datetime import datetime\n",
-    "from annotation_pipeline.molecular_db import build_database, calculate_centroids, upload_mol_dbs_from_dir\n",
+    "from annotation_pipeline.molecular_db import upload_mol_dbs_from_dir\n",
     "from annotation_pipeline.pipeline import Pipeline"
    ]
   },
@@ -207,11 +207,6 @@
    "outputs": [],
    "source": [
     "start_time = datetime.now()\n",
-    "# Build molecular database:\n",
-    "build_database(config, input_db)\n",
-    "polarity = input_ds['polarity']\n",
-    "isocalc_sigma = input_ds['isocalc_sigma']\n",
-    "calculate_centroids(config, input_db, polarity, isocalc_sigma)\n",
     "\n",
     "# Run Annotation Pipeline:\n",
     "pipeline = Pipeline(config, input_ds, input_db, use_cache=False)\n",

--- a/metabolomics/db_config.json.template
+++ b/metabolomics/db_config.json.template
@@ -1,6 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_configN",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/db_config1.json
+++ b/metabolomics/db_config1.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config1",
   "databases": [
     "metabolomics/db/mol_db1.pickle"
   ],

--- a/metabolomics/db_config2.json
+++ b/metabolomics/db_config2.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config2",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/db_config3.json
+++ b/metabolomics/db_config3.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config3",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/db_config4.json
+++ b/metabolomics/db_config4.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config4",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/db_config5.json
+++ b/metabolomics/db_config5.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config5",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/db_config6.json
+++ b/metabolomics/db_config6.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config6",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/db_config7.json
+++ b/metabolomics/db_config7.json
@@ -1,7 +1,5 @@
 {
-  "formulas_chunks": "metabolomics/db/formulas_chunks",
-  "formula_to_id_chunks": "metabolomics/db/formula_to_id",
-  "centroids_chunks": "metabolomics/db/centroids_chunks",
+  "name": "ds_config7",
   "databases": [
     "metabolomics/db/mol_db1.pickle",
     "metabolomics/db/mol_db2.pickle",

--- a/metabolomics/ds_config1.json
+++ b/metabolomics/ds_config1.json
@@ -1,7 +1,7 @@
 {
   "name": "Brain02_Bregma1-42_02",
-  "imzml_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/3013ad4e-9785-4a4f-ae85-9dbeeece8b56/Brain02_Bregma1-42_02.imzML",
-  "ibd_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/3013ad4e-9785-4a4f-ae85-9dbeeece8b56/Brain02_Bregma1-42_02.ibd",
+  "imzml_path": "cos://metaspace-de-public/metabolomics/ds/ds1/Brain02_Bregma1-42_02.imzML",
+  "ibd_path": "cos://metaspace-de-public/metabolomics/ds/ds1/Brain02_Bregma1-42_02.ibd",
   "num_decoys": 20,
   "polarity": "+",
   "isocalc_sigma": 0.000693,

--- a/metabolomics/ds_config2.json
+++ b/metabolomics/ds_config2.json
@@ -1,7 +1,7 @@
 {
   "name": "AZ_Rat_brains",
-  "imzml_path": "https://sm-engine-raw-datasets.s3-eu-west-1.amazonaws.com/AstraZeneca/rat_brains/Image5.imzML",
-  "ibd_path": "https://sm-engine-raw-datasets.s3-eu-west-1.amazonaws.com/AstraZeneca/rat_brains/Image5.ibd",
+  "imzml_path": "cos://metaspace-de-public/metabolomics/ds/ds2/Image5.imzML",
+  "ibd_path": "cos://metaspace-de-public/metabolomics/ds/ds2/Image5.ibd",
   "num_decoys": 20,
   "polarity": "+",
   "isocalc_sigma": 0.001238,

--- a/metabolomics/ds_config3.json
+++ b/metabolomics/ds_config3.json
@@ -1,7 +1,7 @@
 {
   "name": "CT26_xenograft",
-  "imzml_path": "https://sm-engine-raw-datasets.s3-eu-west-1.amazonaws.com/AstraZeneca/Image1_/Image1_CT26.imzML",
-  "ibd_path": "https://sm-engine-raw-datasets.s3-eu-west-1.amazonaws.com/AstraZeneca/Image1_/Image1_CT26.ibd",
+  "imzml_path": "cos://metaspace-de-public/metabolomics/ds/ds3/Image1_CT26.imzML",
+  "ibd_path": "cos://metaspace-de-public/metabolomics/ds/ds3/Image1_CT26.ibd",
   "num_decoys": 20,
   "polarity": "+",
   "isocalc_sigma": 0.001238,

--- a/metabolomics/ds_config4.json
+++ b/metabolomics/ds_config4.json
@@ -1,7 +1,7 @@
 {
   "name": "Mouse_brain",
-  "imzml_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/f6889869-5f9a-4e34-9155-12b289c39772/Mouse+brain+test434x902_50um_10ps_imzML.imzML",
-  "ibd_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/f6889869-5f9a-4e34-9155-12b289c39772/Mouse+brain+test434x902_50um_10ps_imzML.IBD",
+  "imzml_path": "cos://metaspace-de-public/metabolomics/ds/ds4/Mouse+brain+test434x902_50um_10ps_imzML.imzML",
+  "ibd_path": "cos://metaspace-de-public/metabolomics/ds/ds4/Mouse+brain+test434x902_50um_10ps_imzML.IBD",
   "num_decoys": 20,
   "polarity": "+",
   "isocalc_sigma": 0.002476,

--- a/metabolomics/ds_config5.json
+++ b/metabolomics/ds_config5.json
@@ -1,7 +1,7 @@
 {
   "name": "X089-Mousebrain",
-  "imzml_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/bff3b4de-4a7e-4ef8-9269-48720c05fad6/X089-Mousebrain_842x603_12um_A25__DB.imzml",
-  "ibd_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/bff3b4de-4a7e-4ef8-9269-48720c05fad6/X089-Mousebrain_842x603_12um_A25__DB.IBD",
+  "imzml_path": "cos://metaspace-de-public/metabolomics/ds/ds5/X089-Mousebrain_842x603_12um_A25__DB.imzml",
+  "ibd_path": "cos://metaspace-de-public/metabolomics/ds/ds5/X089-Mousebrain_842x603_12um_A25__DB.IBD",
   "num_decoys": 20,
   "polarity": "+",
   "isocalc_sigma": 0.001238,

--- a/metabolomics/ds_config6.json
+++ b/metabolomics/ds_config6.json
@@ -1,7 +1,7 @@
 {
   "name": "microbial_interaction",
-  "imzml_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/f8795949-9c16-419e-a4ea-a75eb4e58d07/microbial_interaction.imzML",
-  "ibd_path": "https://sm-engine-upload.s3-eu-west-1.amazonaws.com/f8795949-9c16-419e-a4ea-a75eb4e58d07/microbial_interaction.ibd",
+  "imzml_path": "cos://metaspace-de-public/metabolomics/ds/ds6/microbial_interaction.imzML",
+  "ibd_path": "cos://metaspace-de-public/metabolomics/ds/ds6/microbial_interaction.ibd",
   "num_decoys": 20,
   "polarity": "+",
   "isocalc_sigma": 0.001238,

--- a/pywren-annotation-pipeline-demo.ipynb
+++ b/pywren-annotation-pipeline-demo.ipynb
@@ -240,7 +240,7 @@
    },
    "outputs": [],
    "source": [
-    "from annotation_pipeline.molecular_db import build_database, calculate_centroids, upload_mol_dbs_from_dir"
+    "from annotation_pipeline.molecular_db import upload_mol_dbs_from_dir"
    ]
   },
   {
@@ -257,43 +257,6 @@
    "source": [
     "# Upload molecular databases into IBM COS\n",
     "upload_mol_dbs_from_dir(config, config['storage']['db_bucket'], 'metabolomics/db', 'metabolomics/db')"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    },
-    "scrolled": true
-   },
-   "outputs": [],
-   "source": [
-    "# Generate formulas dataframes into IBM COS\n",
-    "num_formulas, num_formulas_chunks = build_database(config, input_db)\n",
-    "num_formulas, num_formulas_chunks"
-   ]
-  },
-  {
-   "cell_type": "code",
-   "execution_count": null,
-   "metadata": {
-    "hidden": true,
-    "pycharm": {
-     "metadata": false,
-     "name": "#%%\n"
-    }
-   },
-   "outputs": [],
-   "source": [
-    "# Generate isotopic peaks dataframes into IBM COS\n",
-    "polarity = input_ds['polarity'] # Use '+' if missing from the config, but it's better to get the actual value as it affects the results\n",
-    "isocalc_sigma = input_ds['isocalc_sigma'] # Use 0.001238 if missing from the config, but it's better to get the actual value as it affects the results\n",
-    "num_centroids, num_centroids_chunks = calculate_centroids(config, input_db, polarity, isocalc_sigma)\n",
-    "num_centroids, num_centroids_chunks"
    ]
   },
   {
@@ -320,9 +283,48 @@
   },
   {
    "cell_type": "markdown",
+   "source": [
+    "### Database preprocessing"
+   ],
+   "metadata": {
+    "collapsed": false
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Parse the database\n",
+    "%time pipeline.build_database()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "code",
+   "execution_count": null,
+   "outputs": [],
+   "source": [
+    "# Calculate theoretical centroids for each formula\n",
+    "%time pipeline.calculate_centroids()"
+   ],
+   "metadata": {
+    "collapsed": false,
+    "pycharm": {
+     "name": "#%%\n"
+    }
+   }
+  },
+  {
+   "cell_type": "markdown",
    "metadata": {},
    "source": [
-    "### Preprocessing"
+    "### Dataset preprocessing"
    ]
   },
   {


### PR DESCRIPTION
This PR adds:
* The optimization to pre-select 20 decoy adducts during DB creation, instead of annotating all 80 adducts every time
* The optimization to put DS segments into a DataFrame so that more datatype can be tuned per-column to reduce the size by 33%
* Lots of extra validation steps. If you run `pipeline(debug_validation=True)` it will do some checks on the temp data after many of the steps.
* Assertions to check when [CloudObjects are created with duplicate keys](https://github.com/pywren/pywren-ibm-cloud/issues/322). Even with the smallest DB and DS, this seemed to happen multiple times per full pipeline run. In these cases it's better to restart the step than to continue with bad data that could cause OOMs / bad results later.
* Integration of `build_database` and `calculate_centroids` into `Pipeline`, including using `CloudObject`s, so that it's easier to switch between the two implementations of `build_database`
* Integration of the "big VM-style" versions of DB building and DS segmentation into the main pipeline. The old codepath can be run with `Pipeline(vm_algorithm=False)`. Note that the temp data differs between the two implementations, so modes shouldn't be mixed in the same pipeline.
* Some enhancements to the `PipelineCacher` so that data that is both DS- and DB-specific isn't accidentally shared between runs with the same DS but different DBs.

I've intentionally kept the old codepath intact in case you guys plan to compare before & after the VM conversion.

I have tested it successfully with `pipeline(vm_algorithm=True, debug_validation=True)` with ds1/db1. I also tested the first optimization with ds2/db2 and successfully ran `check_results`, however my internet has been to slow to do that with the second optimzation, since that optimization requires downloading & re-uploading the full dataset every run.

I haven't been able to finish a test with the old code (`Pipeline(vm_algorithm=False)`) because of several PyWren issues: 
* The duplicate CloudObject keys bug
* For some reason the invoker often hangs at exactly 88/256 invocations when running `segment_centr_chunk`. I haven't been able to find out why. All I can see is that PyWren hasn't even started the remaining invocations yet. EDIT: [I found the cause](https://github.com/pywren/pywren-ibm-cloud/issues/324)